### PR TITLE
Add a section on serialization formats

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,7 +628,8 @@
         </p>
         <p>
             In a MARC record, the Plaine & Easie notation components are separated out into subfields. The specifics
-            of this encoding are given in the MARC documentation.
+            of this encoding are given in the <a href="https://www.loc.gov/marc/bibliographic/bd031.html">MARC
+            documentation</a> for the <code>031</code> field.
         </p>
     </section>
     <section>


### PR DESCRIPTION
This change adds a non-normative section on the serialization formats, to provide documentation on the possible input formats for PAE Code.

Fixes #7 