### PR TITLE
Fixed: Remove coded validity note

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -1562,25 +1562,6 @@
             </aside>
         </section>
     </section>
-    <section>
-        <h3>Coded Validity Note</h3>
-        <aside class="note">UNIMARC field 036 $r — MARC21 field 031 $s</aside>
-        <div class="issue" data-number="25"></div>
-        <p>
-            A one-character coded validity note can be introduced by a <code>~</code> at the end of the code.
-        </p>
-        <p>
-            Accepted characters are:
-        </p>
-        <ul>
-            <li><code>?</code>: a mistake in the incipit has not been corrected</li>
-            <li><code>+</code>: a mistake in the incipit has been corrected</li>
-            <li><code>t</code>: incipit has been transcribed into modern notation</li>
-        </ul>
-        <p>
-            These characters may be explained in a note (UNIMARC 036 $q — MARC21 031 $q).
-        </p>
-    </section>
 </section>
 <section class="informative">
     <h2>Representations</h2>


### PR DESCRIPTION
This is already present in the MARC and UNIMARC documentation and is not specific to PAE incipits.