### PR TITLE
Rewrite Clef section

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -137,7 +137,7 @@
         <a href="https://www.loc.gov/marc/bibliographic/bd031.html">MARC21 031</a> fields.
     </p>
 </section>
-<section id="conformance"></section>
+
 <section class="informative">
     <h2>General Principles</h2>
     <div class="issue" data-number="30"></div>
@@ -167,25 +167,29 @@
         <aside class="note">
             UNIMARC field 036 $m; MARC21 field 031 $g
         </aside>
-        <p>
-            The clef code is preceded by <code>%</code> and is three characters long.
-        </p>
         <div class="issue" data-number="33"></div>
         <p>
-            The first character specifies the clef shape.
-        </p>
-
-        <p>
-            The second character is <code>-</code> to indicate modern notation or <code>+</code> to indicate mensural
-            notation.
+            The clef is a required field. Every encoding MUST include a clef.
         </p>
         <p>
-            The third character (numerals 1-5) indicates the position of the clef on the staff, starting from the bottom
-            line.
+            The clef code MUST be three characters long. The first character specifies the clef shape and MUST
+            be one of the values <code>G</code>, <code>g</code> (octave G), <code>C</code>, or <code>F</code>.
         </p>
         <p>
-            If the music is written for a transposing instrument, notate the incipit at sounding pitch.
+            The second character MUST be one of the characters <code>-</code> to indicate modern notation, or
+            <code>+</code> to indicate mensural notation. Certain features in the musical notation are dependent
+            on this value.
         </p>
+        <p>
+            The third character MUST be a numeric value in the range 1-5, and indicates the reference staff line
+            for the clef starting from the bottom.
+        </p>
+        <aside class="note">
+            <p>
+                A value for the clef field is required to ensure the visual rendering of the notation can accurately
+                place the pitch values on the correct line or space within a staff.
+            </p>
+        </aside>
         <aside class="example" title="Encoding Clefs">
             <table class="simple" style="width: 100%;">
                 <thead>
@@ -244,7 +248,6 @@
                     </td>
                     <td class="notation-result"><!-- image here --></td>
                 </tr>
-
                 </tbody>
             </table>
         </aside>
@@ -1654,5 +1657,6 @@
         </aside>
     </section>
 </section>
+<section id="conformance"></section>
 </body>
 </html>

--- a/v2/index.html
+++ b/v2/index.html
@@ -113,11 +113,11 @@
     </style>
 </head>
 <body>
+<div class="issue" data-number="31"></div>
 <p class="copyright">
     CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
 </p>
 <section id="abstract">
-    <div class="issue" data-number="30"></div>
     <p>
         The Plaine & Easie Code is a library standard that enables entering music incipits in modern or mensural
         notation.
@@ -140,6 +140,7 @@
 <section id="conformance"></section>
 <section class="informative">
     <h2>General Principles</h2>
+    <div class="issue" data-number="30"></div>
     <p>
         Music incipits help identify works and facilitate the comparison of historical musical sources.
     </p>


### PR DESCRIPTION
This change contains a rewrite of the clef section of the PAE specification to make it more explicit.

(It will also serve as an example of how this workflow might work in practice...)

Fixes #33 
Fixes #32 