### PR TITLE
Fixed: Move principles to guidelines

### DIFF
--- a/v2/guidelines.html
+++ b/v2/guidelines.html
@@ -70,5 +70,25 @@
 <section id="abstract">
     <p></p>
 </section>
+<section class="informative">
+    <h2>General Principles</h2>
+    <div class="issue" data-number="30"></div>
+    <p>
+        Music incipits help identify works and facilitate the comparison of historical musical sources.
+    </p>
+    <p>
+        Which music incipits to enter depends on the kind of music. Best practice for instrumental music is to enter
+        incipits for the violin or the highest part. For vocal music, enter the highest voice plus the first violin or
+        the highest instrumental part.
+    </p>
+    <p>
+        The incipit should be neither too long nor too short, and make as much musical sense as possible. It should
+        contain at least 3 bars or 10 non-repeated notes.
+    </p>
+    <p>
+        The code should be written on a single line. When using MARC-format subfields, omit the special characters that
+        precede the encoded notes.
+    </p>
+</section>
 </body>
 </html>

--- a/v2/index.html
+++ b/v2/index.html
@@ -95,27 +95,6 @@
     </p>
 </section>
 
-<section class="informative">
-    <h2>General Principles</h2>
-    <div class="issue" data-number="30"></div>
-    <p>
-        Music incipits help identify works and facilitate the comparison of historical musical sources.
-    </p>
-    <p>
-        Which music incipits to enter depends on the kind of music. Best practice for instrumental music is to enter
-        incipits for the violin or the highest part. For vocal music, enter the highest voice plus the first violin or
-        the highest instrumental part.
-    </p>
-    <p>
-        The incipit should be neither too long nor too short, and make as much musical sense as possible. It should
-        contain at least 3 bars or 10 non-repeated notes.
-    </p>
-    <p>
-        The code should be written on a single line. When using MARC-format subfields, omit the special characters that
-        precede the encoded notes.
-    </p>
-</section>
-
 <section class="normative">
     <h2>The Plaine & Easie Code</h2>
     <section>


### PR DESCRIPTION
This commit moves the "General Principles" section to the encoding guidelines.

Refs #50 