### PR TITLE
Fixed: Re-ordering and other structural changes

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -46,11 +46,12 @@
             shortName: "paec",
             maxTocLevel: 4,
             localBiblio: {
-                "SCIENTIFIC-PITCH": {
-                    "authors": "Young, Robert W.",
-                    "title": "Terminology for Logarithmic Frequency Units",
-                    "href": "https://doi.org/10.1121/1.1916017",
-                    "publisher": "The Journal of the Acoustical Society of America, vol. 11, no. 1 (1939), 134–139.",
+                "ScientificPitch": {
+                    authors: ["Young, Robert W"],
+                    title: "Terminology for Logarithmic Frequency Units",
+                    href: "https://doi.org/10.1121/1.1916017",
+                    publisher: "The Journal of the Acoustical Society of America, vol. 11, no. 1 (1939), 134–139.",
+                    rawDate: "July 1939"
                 }
             }
         };
@@ -525,7 +526,7 @@
             <h4>Octaves</h4>
             <div class="issue" data-number="69"></div>
             <p>
-                Octaves in Plaine &amp; Easie are enumerated according to [[SCIENTIFIC-PITCH]]. The boundary note
+                Octaves in Plaine &amp; Easie are enumerated according to [[ScientificPitch]]. The boundary note
                 between octaves is C.
             </p>
             <p>
@@ -1647,6 +1648,7 @@
     </section>
 </section>
 <section id="conformance"></section>
+<section id="references"></section>
 
 <script type="application/javascript" src="/static/js/verovio-rendering.js"></script>
 </body>

--- a/v2/index.html
+++ b/v2/index.html
@@ -44,7 +44,15 @@
             historyURI: null,
             license: null,
             shortName: "paec",
-            maxTocLevel: 4
+            maxTocLevel: 4,
+            localBiblio: {
+                "SCIENTIFIC-PITCH": {
+                    "authors": "Young, Robert W.",
+                    "title": "Terminology for Logarithmic Frequency Units",
+                    "href": "https://doi.org/10.1121/1.1916017",
+                    "publisher": "The Journal of the Acoustical Society of America, vol. 11, no. 1 (1939), 134–139.",
+                }
+            }
         };
     </script>
     <script type="application/javascript" src="/static/js/verovio-rendering.js"></script>
@@ -514,20 +522,24 @@
         <div class="issue" data-number="43"></div>
         <div class="issue" data-number="56"></div>
         <section>
-            <h4>Octave</h4>
+            <h4>Octaves</h4>
             <div class="issue" data-number="69"></div>
             <p>
-                Octaves are indicated using the apostrophe, <code>'</code> for octave C4 and above, and the comma,
-                <code>,</code>, for octaves C3 and below. These characters are repeated to indicate successively
-                higher or lower octaves: <code>'</code> indicates C4, <code>''</code> indicates C5, <code>'''</code>
-                indicates C6, and so on.
+                Octaves in Plaine &amp; Easie are enumerated according to [[SCIENTIFIC-PITCH]]. The boundary note
+                between octaves is C.
             </p>
             <p>
-                The octave indication MAY be omitted. If the octave is omitted, the last specified octave
-                indication is used.
+                Octaves are indicated using the apostrophe <code>'</code> for octave C4 and above, and the comma
+                <code>,</code> for octaves C3 and below. These characters are repeated to indicate successively
+                higher or lower octaves: <code>''</code> indicates C5, <code>'''</code> indicates C6, <code>,,</code>
+                indicates C2, and so on.
             </p>
             <p>
-                An encoding MAY omit all octave indications. If no octave is supplied on any note, all notes are
+                The octave indication for a given note MAY be omitted. If the octave is omitted, the last specified
+                octave indication is used.
+            </p>
+            <p>
+                An <a>encoding</a> MAY omit all octave indications. If no octave is supplied on any note, all notes are
                 assumed to be in octave C4.
             </p>
             <aside class="example" title="Encoding Octaves">
@@ -916,63 +928,6 @@
             <p>C, D, E, F, G, A, B</p>
         </section>
         <section>
-            <h4>Grace Notes</h4>
-            <div class="issue" data-number="22"></div>
-            <div class="issue" data-number="75"></div>
-            <aside class="example" title="Encoding Grace Notes">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'2A''gC{''8D'8B}''4C"
-                                }
-                            </script>
-                            <code>g</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>acciaccatura (without rhythmic value, precedes the note name)</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'2A'gB{'8A'8G}'4A"
-                                }
-                            </script>
-                            <code>q</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>appoggiatura (with rhythmic value, precedes the note name)</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'2A''qq{'8B''8C}r{''8D'8B}''4C"
-                                }
-                            </script>
-                            <code>qq..r</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>double appoggiatura, slide, or multiple appoggiatura (with rhythmic value)</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
             <h4>Rests</h4>
             <div class="issue" data-number="29"></div>
             <div class="issue" data-number="41"></div>
@@ -1064,7 +1019,89 @@
             </aside>
         </section>
         <section>
-            <h4>Bar (measure) Lines</h4>
+            <h4>Chords</h4>
+            <div class="issue" data-number="2"></div>
+            <div class="issue" data-number="60"></div>
+            <div class="issue" data-number="65"></div>
+            <p>
+                Enter chords from the highest to the lowest note, each one separated by <code>^</code>.
+            </p>
+            <aside class="example" title="Encoding Chords">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "''2D^'A^xF"
+                                }
+                            </script>
+                            <code>''2D^'A^xF</code>
+                        </td>
+                        <td class="notation-result"></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Beaming</h4>
+            <div class="issue" data-number="45"></div>
+            <table class="simple">
+                <thead>
+                <tr>
+                    <th>Code</th>
+                    <th>Remarks</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td><code>{</code></td>
+                    <td>beginning of beaming</td>
+                </tr>
+                <tr>
+                    <td><code>}</code></td>
+                    <td>end of beaming</td>
+                </tr>
+                </tbody>
+            </table>
+
+            <aside class="example" title="Encoding Beams">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "keysig": "bBEA",
+                                    "timesig": "4/4",
+                                    "data": "{''6E'B8G}{GA}-''C{'3B8..G}"
+                                }
+                            </script>
+                            <code>{''6E'B8G}{GA}-''C{'3B8..G}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Bar Lines</h4>
             <div class="issue" data-number="44"></div>
             <aside class="example" title="Encoding Bar Lines">
                 <table class="simple" style="width: 100%">
@@ -1145,120 +1182,9 @@
                     </tbody>
                 </table>
             </aside>
-
         </section>
         <section>
-            <h4>Other Symbols</h4>
-            <div class="issue" data-number="1"></div>
-            <div class="issue" data-number="3"></div>
-            <div class="issue" data-number="28"></div>
-            <aside class="example" title="Encoding Other Symbols">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "''4Ct"
-                                }
-                            </script>
-                            <code>t</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>trill (immediately follows the note)</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "''4C+''4C"
-                                }
-                            </script>
-                            <code>+</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>tie (immediately follows the note; only for notes of the same pitch, not for slurs)</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "(''4C)"
-                                }
-                            </script>
-                            <code>( )</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>fermata (include only one note or rest; accidentals or octave symbols must be outside the
-                            parentheses. See also "Special rhythmic groupings" below.)
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Beaming</h4>
-            <div class="issue" data-number="45"></div>
-            <table class="simple">
-                <thead>
-                <tr>
-                    <th>Code</th>
-                    <th>Remarks</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td><code>{</code></td>
-                    <td>beginning of beaming</td>
-                </tr>
-                <tr>
-                    <td><code>}</code></td>
-                    <td>end of beaming</td>
-                </tr>
-                </tbody>
-            </table>
-
-            <aside class="example" title="Encoding Beams">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "keysig": "bBEA",
-                                    "timesig": "4/4",
-                                    "data": "{''6E'B8G}{GA}-''C{'3B8..G}"
-                                }
-                            </script>
-                            <code>{''6E'B8G}{GA}-''C{'3B8..G}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Special Rhythmic Groupings</h4>
-
+            <h4>Tuplets</h4>
             <table class="simple">
                 <thead>
                 <tr>
@@ -1343,6 +1269,114 @@
             <p>
                 The rhythmic value inside the parentheses is required.
             </p>
+        </section>
+        <section>
+            <h4>Other Symbols</h4>
+            <div class="issue" data-number="1"></div>
+            <div class="issue" data-number="3"></div>
+            <div class="issue" data-number="28"></div>
+            <section>
+                <h5>Grace Notes</h5>
+                <div class="issue" data-number="22"></div>
+                <div class="issue" data-number="75"></div>
+                <aside class="example" title="Encoding Grace Notes">
+                    <table class="simple" style="width: 100%">
+                        <thead>
+                        <tr>
+                            <th>Code</th>
+                            <th>Notation</th>
+                            <th>Remarks</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr class="notation-example">
+                            <td class="notation-code">
+                                <script type="application/json">
+                                    {
+                                        "clef": "G-2",
+                                        "data": "'2A''gC{''8D'8B}''4C"
+                                    }
+                                </script>
+                                <code>g</code>
+                            </td>
+                            <td class="notation-result"></td>
+                            <td>acciaccatura (without rhythmic value, precedes the note name)</td>
+                        </tr>
+                        <tr class="notation-example">
+                            <td class="notation-code">
+                                <script type="application/json">
+                                    {
+                                        "clef": "G-2",
+                                        "data": "'2A'gB{'8A'8G}'4A"
+                                    }
+                                </script>
+                                <code>q</code>
+                            </td>
+                            <td class="notation-result"></td>
+                            <td>appoggiatura (with rhythmic value, precedes the note name)</td>
+                        </tr>
+                        <tr class="notation-example">
+                            <td class="notation-code">
+                                <script type="application/json">
+                                    {
+                                        "clef": "G-2",
+                                        "data": "'2A''qq{'8B''8C}r{''8D'8B}''4C"
+                                    }
+                                </script>
+                                <code>qq..r</code>
+                            </td>
+                            <td class="notation-result"></td>
+                            <td>double appoggiatura, slide, or multiple appoggiatura (with rhythmic value)</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </aside>
+            </section>
+            <section>
+                <h5>Trill</h5>
+                <p class="advisement">
+                    TODO: Expand on trill encoding
+                </p>
+            </section>
+            <section>
+                <h5>Fermata</h5>
+                <p class="advisement">
+                    TODO: Expand on fermata encoding
+                </p>
+            </section>
+            <section>
+                <h5>Tremolo, Slash</h5>
+                <p>
+                    Notation abbreviations, such as tremolo, slash, etc., must be written out in full using the actual
+                    notation.
+                </p>
+                <aside class="example" title="Encoding Clef, Key Signature, and Time Signature Changes">
+                    <table class="simple" style="width: 100%">
+                        <thead>
+                        <tr>
+                            <th>Code</th>
+                            <th>Notation</th>
+                            <th>Remarks</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr class="notation-example">
+                            <td class="notation-code">
+                                <script type="application/json">
+                                    {
+                                        "clef": "G-2",
+                                        "data": "{''8CCCC}"
+                                    }
+                                </script>
+                                <code>{''8CCCC}</code>
+                            </td>
+                            <td class="notation-result"></td>
+                            <td>Tremolo on C</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </aside>
+            </section>
         </section>
         <section>
             <h4>Shortcuts</h4>
@@ -1498,72 +1532,6 @@
                                 }
                             </script>
                             <code>%C-1 $bBEA @c '2A-//$xFC 8B-4-2-/@3/2 1C2-//</code>
-                        </td>
-                        <td class="notation-result"></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Abbreviations</h4>
-            <p>
-                Notation abbreviations, such as tremolo, slash, etc., must be written out in full using the actual
-                notation.
-            </p>
-            <aside class="example" title="Encoding Clef, Key Signature, and Time Signature Changes">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "{''8CCCC}"
-                                }
-                            </script>
-                            <code>{''8CCCC}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Tremolo on C</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Chords</h4>
-            <div class="issue" data-number="2"></div>
-            <div class="issue" data-number="60"></div>
-            <div class="issue" data-number="65"></div>
-            <p>
-                Enter chords from the highest to the lowest note, each one separated by <code>^</code>.
-            </p>
-            <aside class="example" title="Encoding Chords">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "''2D^'A^xF"
-                                }
-                            </script>
-                            <code>''2D^'A^xF</code>
                         </td>
                         <td class="notation-result"></td>
                     </tr>


### PR DESCRIPTION
This PR is a bit of a monolith. It contains the following changes:

1. It restructures the order of sections. It did not make sense that grace notes came before beaming in the order. I understand that the ordering was (roughly) given in "encoding" order, but in practice this meant that fairly important sections, like chords, were placed last as they did not really fit.
2. It moves some of the "minor" encoding features to the "Other" section.
3. Some small tweaking of the octave sections, and an inclusion of a reference to scientific pitch

Fixes #69