### PR TITLE
Fixed chords

### DIFF
--- a/v2/guidelines.html
+++ b/v2/guidelines.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>Plaine & Easie Encoding Guidelines</title>
+        <title>Plaine &amp; Easie Encoding Guidelines</title>
     <script
             src="https://www.w3.org/Tools/respec/respec-w3c"
             class="remove"

--- a/v2/index.html
+++ b/v2/index.html
@@ -1363,7 +1363,7 @@
             <p>
                A <a>duration</a> value MAY precede the <code>^</code>. Two or more <a>note names</a>
                (with optional octave and accidental indications) MUST immediately follow this character.
-               The notes MUST be ordered from the lowest to the highest on the staff line. A <code>></code>
+               The notes SHOULD be ordered from the lowest to the highest on the staff line. A <code>></code>
                MUST be used to end the chord. A duration value for the individual notes within a chord MUST
                NOT be supplied.
             </p>

--- a/v2/index.html
+++ b/v2/index.html
@@ -1382,7 +1382,7 @@
             </p>
             <p>
                 The <code>v</code> MUST follow the closing <code>></code>. It MUST not be separated from
-                the chord by any character EXCEPT a <a>bar line</a>. It MAY be repeated as many times as
+                the chord by any character EXCEPT <a>bar line</a> characters. It MAY be repeated as many times as
                 necessary, and each repetition MAY change its duration.
             </p>
             <aside class="example" title="Encoding Chords">

--- a/v2/index.html
+++ b/v2/index.html
@@ -1358,7 +1358,29 @@
             <div class="issue" data-number="60"></div>
             <div class="issue" data-number="65"></div>
             <p>
-                Enter chords from the highest to the lowest note, each one separated by <code>^</code>.
+                Notes in a chords are enclosed in the characters <code>^</code> and <code>></code>.
+            </p>
+            <p>
+               A <a>duration</a> value MAY precede the <code>^</code>. Two or more <a>note names</a>
+               (with optional octave and accidental indications) MUST immediately follow this character.
+               The notes MUST be ordered from the lowest to the highest on the staff line. A <code>></code>
+               MUST be used to end the chord. A duration value for the individual notes within a chord MUST
+               NOT be supplied.
+            </p>
+            <p>
+                If the duration is omitted, the last specified duration is used. If no duration is
+                supplied in the <a>encoding</a> a default duration of <code>4</code> is assumed.
+            </p>
+            <p>
+                A <code>v</code> MAY be used to indicate a tied chord. A duration value MAY immediately
+                precede the <code>v</code>. If the duration is omitted, the last specified duration is
+                used. If no duration is supplied in the <a>encoding</a> a default duration of <code>4</code>
+                is assumed.
+            </p>
+            <p>
+                The <code>v</code> MUST follow the closing <code>></code>. It MUST not be separated from
+                the chord by any character EXCEPT a <a>bar line</a>. It MAY be repeated as many times as
+                necessary, and each repetition MAY change its duration.
             </p>
             <aside class="example" title="Encoding Chords">
                 <table class="simple" style="width: 100%">
@@ -1377,7 +1399,19 @@
                                     "data": "''2D^'A^xF"
                                 }
                             </script>
-                            <code>''2D^'A^xF</code>
+                            <code>2^'AxF>/2^AxF>/</code>
+                        </td>
+                        <td class="notation-result"></td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "''2D^'A^xF"
+                                }
+                            </script>
+                            <code>2^'AxF>/2v/4v//</code>
                         </td>
                         <td class="notation-result"></td>
                     </tr>

--- a/v2/index.html
+++ b/v2/index.html
@@ -1372,6 +1372,9 @@
                 supplied in the <a>encoding</a> a default duration of <code>4</code> is assumed.
             </p>
             <p>
+                A <code>p</code> character MAY follow the duration to indicate the chord has a fermata.
+            </p>
+            <p>
                 A <code>v</code> MAY be used to indicate a tied chord. A duration value MAY immediately
                 precede the <code>v</code>. If the duration is omitted, the last specified duration is
                 used. If no duration is supplied in the <a>encoding</a> a default duration of <code>4</code>
@@ -1388,6 +1391,7 @@
                     <tr>
                         <th>Code</th>
                         <th>Notation</th>
+                        <th>Remarks</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -1402,7 +1406,22 @@
                             <code>2^'AxF>/2^AxF>/</code>
                         </td>
                         <td class="notation-result"></td>
+                        <td>Two chords</td>
                     </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "''2D^'A^xF"
+                                }
+                            </script>
+                            <code>2p^AxF></code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>A chord with a fermata</td>
+                    </tr>
+
                     <tr class="notation-example">
                         <td class="notation-code">
                             <script type="application/json">
@@ -1414,6 +1433,7 @@
                             <code>2^'AxF>/2v/4v//</code>
                         </td>
                         <td class="notation-result"></td>
+                        <td>A chord tied over three measures with varying durations</td>
                     </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
This is a first attempt at reaching some agreement on the encoding of chords.

Chords are enclosed in ^ and >. The duration of the chord is given prior to the opening ^ (similar to tuplets). No duration values are allowed within the chord. (i.e., chords with notes with differing durations are not allowed.)

~Similar to repeat groups and repeat measures, tied chords are repeated with the v character.~ This has evolved, see #60  This means that you don't have to spell out the notes of the chords, and only identical tied chords are supported, varying only by their duration.

A p may be used to indicate a fermata over the chord.

Fixes https://github.com/rism-digital/pae-code-spec/issues/65
Fixes https://github.com/rism-digital/pae-code-spec/issues/60
Fixes https://github.com/rism-digital/pae-code-spec/issues/2

Examples:

`2^CEG>`

![image](https://github.com/rism-digital/pae-code-spec/assets/163183/9896119a-3c59-4626-8825-dc3443149b97)

`{8^CEG>^DxFA>}`

![image](https://github.com/rism-digital/pae-code-spec/assets/163183/8c12ee06-956f-4366-abb9-0806c1a96ade)
