### PR TITLE
Fixed: Change appogiatura groups to `y`

### DIFF
--- a/v2/changes.html
+++ b/v2/changes.html
@@ -187,8 +187,8 @@
                     character in the clef for indicating mensural notation.
                 </p>
             </section>
-			<section>
-				<h3>Appogiatura Group Opening Character</h3>
+            <section>
+                <h3>Appogiatura Group Opening Character</h3>
                 <p>
                     Previously the characters <code>qq</code> were used to start
                     an appogiatura (a.k.a grace note) group. However, this was
@@ -202,7 +202,7 @@
                     In Version 2 the start of an appogiatura group is now
                     signalled by the lower-case letter <code>y</code>. It is
                     still ended by the lower-case letter <code>r</code>.
-				</p>
+                </p>
         </section>
         <section>
             <h2>New Features</h2>

--- a/v2/changes.html
+++ b/v2/changes.html
@@ -164,6 +164,23 @@
                     explanatory notes in a notes field.
                 </p>
             </section>
+            <section>
+                <h3>Appogiatura Group Opening Character</h3>
+                <p>
+                    Previously the characters <code>qq</code> were used to start
+                    an appogiatura (a.k.a grace note) group. However, this was
+                    the only instance in the Plaine &amp; Easie Code where two
+                    characters were used to start a group. It also meant that
+                    parsing the code was a bit more difficult, since it created
+                    ambiguities between a single `q`, or a single appogiatura
+                    notes, or a group of notes.
+                </p>
+                <p>
+                    In Version 2 the start of an appogiatura group is now
+                    signalled by the lower-case letter <code>y</code>. It is
+                    still ended by the lower-case letter <code>r</code>.
+                </p>
+            </section>
         </section>
         <section>
             <h2>New Features</h2>

--- a/v2/index.html
+++ b/v2/index.html
@@ -1420,7 +1420,7 @@
                                     "data": "'8{ABqq{''6CD}r'8AB}"
                                 }
                             </script>
-                            <code>8{ABqq{''CD}r'AB}</code>
+                            <code>8{ABy{''CD}r'AB}</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>Beaming with a Grace Note Group</td>
@@ -1763,13 +1763,13 @@
                 <h5>Appogiatura Group</h5>
                 <p>
                     For multiple consecutive appogiatura notes, the appogiatura group SHOULD
-                    be used. The lower-case characters <code>qq</code> MUST be given as the first
+                    be used. The lower-case character <code>y</code> MUST be given as the first
                     characters before the first note of the group, and the lower-case character
                     <code>r</code> MUST be the last character in the final note of the group.
                     There MUST be more than one note in a appogiatura group.
                 </p>
                 <p>
-                    The <code>r</code> character MUST follow the closing beam character
+                    The <code>r</code> character MUST follow any closing beam character
                     that is part of the appogiatura group.
                 </p>
                 <p>
@@ -1821,7 +1821,7 @@
                                     "data": "'4Aqq''{'8B''8C}r{''8D'8B}"
                                 }
                             </script>
-                            <code>'4Aqq''{'8B''8C}r{''8D'8B}</code>
+                            <code>'4Ay''{'8B''8C}r{''8D'8B}</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>Appoggiatura group</td>
@@ -1834,7 +1834,7 @@
                                     "data": "{'8Aqq''{'8B''8C}r''8D}"
                                 }
                             </script>
-                            <code>{'8Aqq''{'8B''8C}r''8D}</code>
+                            <code>{'8Ay''{'8B''8C}r''8D}</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>Beamed appoggiatura group within an outer beam</td>


### PR DESCRIPTION
Note that the Verovio code remains the same so that the examples render correctly. This will be addressed in #89.

Fixes #113