### PR TITLE
Overhaul structure

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -191,722 +191,579 @@
         figure.</dd>
     </dl>
 </section>
-<section class="normative">
-    <h2>The Plaine &amp; Easie Code</h2>
+<section>
     <div class="issue" data-number="57"></div>
+    <h2>Staff Definitions</h2>
+    <p>
+        The clef, key signature, and time signature of an incipit is defined separately from the
+        <a href="#musical-notation">Musical Notation</a> of the incipit. These properties affect the whole staff.
+    </p>
     <section>
-        <h3>Staff Definitions</h3>
+        <div class="issue" data-number="72"></div>
+        <h4>Clef</h4>
         <p>
-            The clef, key signature, and time signature of an incipit is defined separately from the
-            <a>Musical Notation</a> of the incipit. These properties affect the whole staff.
+            Every encoding MUST include a clef.
         </p>
-        <section>
-            <div class="issue" data-number="72"></div>
-            <h4>Clef</h4>
+        <p>
+            The clef code MUST be three characters long. The first character specifies the clef shape and MUST
+            be one of the values <code>G</code>, <code>g</code> (octave G), <code>C</code>, or <code>F</code>.
+        </p>
+        <p>
+            The second character MUST be one of the characters <code>-</code> to indicate modern notation,
+            <code>+</code> to indicate mensural notation, or <code>:</code> to indicate neume notation. Each
+            of these notations impose different interpretations on the music notation in the incipit.
+        </p>
+        <p>
+            The third character MUST be a numeric value in the range 1-5, and indicates the reference staff line
+            for the clef starting from the bottom.
+        </p>
+        <aside class="note">
             <p>
-                Every encoding MUST include a clef.
+                A value for the clef field is required to ensure the visual rendering of the notation can accurately
+                place the pitch values on the correct line or space within a staff. Certain features in the musical
+                notation are dependent on the second indicator.
             </p>
-            <p>
-                The clef code MUST be three characters long. The first character specifies the clef shape and MUST
-                be one of the values <code>G</code>, <code>g</code> (octave G), <code>C</code>, or <code>F</code>.
-            </p>
-            <p>
-                The second character MUST be one of the characters <code>-</code> to indicate modern notation,
-                <code>+</code> to indicate mensural notation, or <code>:</code> to indicate neume notation. Each
-                of these notations impose different interpretations on the music notation in the incipit.
-            </p>
-            <p>
-                The third character MUST be a numeric value in the range 1-5, and indicates the reference staff line
-                for the clef starting from the bottom.
-            </p>
-            <aside class="note">
-                <p>
-                    A value for the clef field is required to ensure the visual rendering of the notation can accurately
-                    place the pitch values on the correct line or space within a staff. Certain features in the musical
-                    notation are dependent on the second indicator.
-                </p>
-            </aside>
-            <p>
-                The clef indications imply the octave in which each note on the staff will sound and
-                its visual placement on the staff. The following table gives the indicative octave and note
-                for the bottom and top lines of each staff.
-            </p>
-            <table class="data">
-                <colgroup class="header"></colgroup>
-                <colgroup span="2"></colgroup>
+        </aside>
+        <p>
+            The clef indications imply the octave in which each note on the staff will sound and
+            its visual placement on the staff. The following table gives the indicative octave and note
+            for the bottom and top lines of each staff.
+        </p>
+        <table class="data">
+            <colgroup class="header"></colgroup>
+            <colgroup span="2"></colgroup>
+            <thead>
+                <tr>
+                    <th>Shape and Line</th>
+                    <th>Bottom Line Octave and Note</th>
+                    <th>Top Line Octave and Note</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>G-2</code></td>
+                    <td><code>'E</code> (E4)</td>
+                    <td><code>''F</code> (F5)</td>
+                </tr>
+                <tr>
+                    <td><code>F-4</code></td>
+                    <td><code>,,G</code> (G2)</td>
+                    <td><code>,A</code> (A3)</td>
+                </tr>
+                <tr>
+                    <td><code>g-2</code></td>
+                    <td><code>,E</code> (E3)</td>
+                    <td><code>'F</code> (F4)</td>
+                </tr>
+                <tr>
+                    <td><code>C-3</code></td>
+                    <td><code>,F</code> (F3)</td>
+                    <td><code>'G</note> (G4)</>
+                </tr>
+            </tbody>
+        </table>
+        <aside class="example" title="Encoding Clefs">
+            <table class="simple" style="width: 100%;">
                 <thead>
-                    <tr>
-                        <th>Shape and Line</th>
-                        <th>Bottom Line Octave and Note</th>
-                        <th>Top Line Octave and Note</th>
-                    </tr>
+                <tr>
+                    <th>Code</th>
+                    <th>Notation</th>
+                    <th>Remarks</th>
+                </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td><code>G-2</code></td>
-                        <td><code>'E</code> (E4)</td>
-                        <td><code>''F</code> (F5)</td>
-                    </tr>
-                    <tr>
-                        <td><code>F-4</code></td>
-                        <td><code>,,G</code> (G2)</td>
-                        <td><code>,A</code> (A3)</td>
-                    </tr>
-                    <tr>
-                        <td><code>g-2</code></td>
-                        <td><code>,E</code> (E3)</td>
-                        <td><code>'F</code> (F4)</td>
-                    </tr>
-                    <tr>
-                        <td><code>C-3</code></td>
-                        <td><code>,F</code> (F3)</td>
-                        <td><code>'G</note> (G4)</>
-                    </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "data": ""
+                            }
+                        </script>
+                        <code>G-2</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>G clef ("treble")</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "C+2",
+                                "data": ""
+                            }
+                        </script>
+                        <code>C+2</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>C clef in Mensural</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "F-4",
+                                "data": ""
+                            }
+                        </script>
+                        <code>F-4</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>F clef ("bass")</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "g-2",
+                                "data": ""
+                            }
+                        </script>
+                        <code>g-2</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>Octave G clef</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G:2",
+                                "data": ""
+                            }
+                        </script>
+                        <code>g-2</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>Neume G clef</td>
+                </tr>
                 </tbody>
             </table>
-            <aside class="example" title="Encoding Clefs">
-                <table class="simple" style="width: 100%;">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>G-2</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>G clef ("treble")</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "C+2",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>C+2</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>C clef in Mensural</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "F-4",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>F-4</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>F clef ("bass")</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "g-2",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>g-2</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Octave G clef</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G:2",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>g-2</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Neume G clef</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Key Signature</h4>
-            <p>
-                An encoding MAY include a key signature.
-            </p>
-            <p>
-                The character <code>x</code> indicates sharp keys and <code>b</code> flat keys. These characters MUST be
-                followed by a list of <a href="#note-names">note names</a> that indicate the altered notes.
-            </p>
-            <p>
-                The list of note names in a key signature SHOULD follow the <a>circle of fifths</a> ordering. Missing
-                accidentals in this list SHOULD be supplied by the <a>transcriber</a>. Note names MUST NOT be repeated.
-            </p>
-            <p>
-                All notes given in the key signature MUST be interpreted as having their sounding pitch altered
-                accordingly. In cases where a note in a key signature is further altered by use of an <a>accidental</a>,
-                directly on the note, the <a>written pitch</a> and <a>sounding pitch</a> indicated by the accidental
-                will take precedence.
-            </p>
-            <p>
-                A key signature containing a single <code>n</code> character MAY be supplied to indicate a natural key
-                signature, i.e., C Major or A minor. This character MUST NOT be followed by any note names.
-            </p>
-            <p>
-                A key signature MAY contain note names within square brackets <code>[]</code> to indicate that the
-                note names are not in the original source and have been supplied by the <a>transcriber</a>. Consecutively
-                supplied note names MUST be within a single set of brackets. A key signature MAY contain more than one
-                set of non-consecutive bracket groups.
-            </p>
-            <aside class="note">
-                <p>
-                    While the key signature is an optional field, the absence of a key signature in the
-                    encoding can be ambiguous. It may be interpreted either as a completely natural key signature (i.e.,
-                    C major) or it may indicate that a key signature was missing entirely from the original source.
-                    The presence of the <code>n</code> character can be used to explicitly mark a key signature with no
-                    sharps or flats. For sources where no key signature is needed, it is recommended to use
-                    the <code>n</code> key signature to make this encoding explicit.
-                </p>
-            </aside>
-            <p>
-                For neume notation, the key signature MUST be omitted. Any alterations to individual pitches MUST
-                be encoded as accidentals.
-            </p>
-            <aside class="example" title="Encoding Key Signatures">
-                <table class="simple" style="width:100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "C-1",
-                                    "keysig": "xFC",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>xFC</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>F and C sharp (key is D major or B minor).</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "keysig": "bBEA",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>bBEA</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>B, E, A flat (key is E-flat major or C minor).</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "keysig": "bB[EA]",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>bB[EA]</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>The E and A flats in the key signature have been supplied by the <a>transcriber</a>.</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "keysig": "n",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>n</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>The natural key signature with no accidentals.</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "keysig": "xF[C]G[D]",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>xF[C]G[D]</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>F, C, G, and D sharp. The C and D are marked as supplied by the <a>transcriber</a>.</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <div class="issue" data-number="64"></div>
-            <div class="issue" data-number="70"></div>
-            <div class="issue" data-number="71"></div>
-            <div class="issue" data-number="73"></div>
-            <div class="issue" data-number="103"></div>
-            <h4>Time Signature</h4>
-            <p>
-                An encoding MAY include a time signature.
-            </p>
-            <p>
-                There are two main categories of time signature forms, <a>Common Western Music Notation</a>
-                (<abbr title="Common Western Music Notation">CWMN</abbr>) and Mensural.
-            </p>
-            <p>
-                For neume notation, the time signature MUST be omitted.
-            </p>
-            <p>
-                <abbr title="Common Western Music Notation">CWMN</abbr> and Mensural time signatures MUST NOT
-                be mixed on the same staff.
-            </p>
-            <p>
-                <abbr title="Common Western Music Notation">CWMN</abbr> time signatures are expressed as one number
-                above another. These numbers MUST be separated by a <code>/</code> character. Any positive digit MAY
-                be used, but <a>encoders</a> SHOULD use commonly accepted values where possible. The <code>c</code>
-                ("common", or <code>4/4</code>) and <code>c/</code> ("alla breve", or <code>2/4</code>) characters
-                MAY be used.
-            </p>
-            <p>
-                <abbr title="Common Western Music Notation">CWMN</abbr> time signatures that indicate alternating
-                measures MAY be indicated by transcribing both. These MUST be separated by a vertical bar
-                <code>|</code> character.
-            </p>
-            <p>
-                For mensuration signs, the <code>c</code> and <code>o</code> characters indicate <em>tempus
-                imperfectus</em> and <em>tempus perfectus</em>, respectively. The <code>.</code> character indicates
-                "major" prolation; omitting <code>.</code> indicates "minor" prolation. A <code>/</code> character may
-                follow the <em>tempus</em> character to indicate diminution.
-            </p>
-            <p>
-                A mensuration sign MAY include a numerical component as a proportion or augmentation,
-                indicating <em>Modus cum tempore</em>. These numerals MUST be either a <code>3</code> or <code>2</code>.
-                These numbers MAY be combined and separated by a <code>/</code>.
-            </p>
-            <aside class="example" title="Encoding Time Signatures and Mensuration Signs">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "timesig": "2/4",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>2/4</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td></td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "timesig": "12/16",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>12/16</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td></td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "timesig": "c",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>c</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td>common time</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "timesig": "c/",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>c/</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td><i>alla breve</i></td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "C+3",
-                                    "timesig": "o",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>o</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td>Perfect <em>tempus</em>, minor prolation</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "C+3",
-                                    "timesig": "o.",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>o.</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td>Perfect <em>tempus</em>, major prolation</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "C+3",
-                                    "timesig": "c3",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>c3</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td>Perfect <em>tempus</em>, imperfect minor <em>modus</em></td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "C+3",
-                                    "timesig": "c2",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>c2</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td>Imerfect <em>tempus</em>, imperfect minor <em>modus</em></td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G+2",
-                                    "timesig": "c/",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>c/</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td>With <em>diminution</em></td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "timesig": "3/4|4/4",
-                                    "data": ""
-                                }
-                            </script>
-                            <code>3/4|4/4</code>
-                        </td>
-                        <td class="notation-result">
-                        </td>
-                        <td><i>Not currently supported by Verovio</i></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
+        </aside>
     </section>
     <section>
-        <h3>Musical Notation</h3>
-        <div class="issue" data-number="24"></div>
-        <div class="issue" data-number="97"></div>
-        <section>
-            <h4>Structure</h4>
+        <h4>Key Signature</h4>
+        <p>
+            An encoding MAY include a key signature.
+        </p>
+        <p>
+            The character <code>x</code> indicates sharp keys and <code>b</code> flat keys. These characters MUST be
+            followed by a list of <a href="#note-names">Note Names</a> that indicate the altered notes.
+        </p>
+        <p>
+            The list of note names in a key signature SHOULD follow the <a>circle of fifths</a> ordering. Missing
+            accidentals in this list SHOULD be supplied by the <a>transcriber</a>. Note names MUST NOT be repeated.
+        </p>
+        <p>
+            All notes given in the key signature MUST be interpreted as having their sounding pitch altered
+            accordingly. In cases where a note in a key signature is further altered by use of an
+            <a href="#accidental">accidental</a>, directly on the note, the <a>written pitch</a> and
+            <a>sounding pitch</a> indicated by the accidental will take precedence.
+        </p>
+        <p>
+            A key signature containing a single <code>n</code> character MAY be supplied to indicate a natural key
+            signature, i.e., C Major or A minor. This character MUST NOT be followed by any note names.
+        </p>
+        <p>
+            A key signature MAY contain note names within square brackets <code>[]</code> to indicate that the
+            note names are not in the original source and have been supplied by the <a>transcriber</a>. Consecutively
+            supplied note names MUST be within a single set of brackets. A key signature MAY contain more than one
+            set of non-consecutive bracket groups.
+        </p>
+        <aside class="note">
             <p>
-                The Musical Notation section of an encoding is given as a single line of characters. These characters
-                represent a staff of musical notation. To represent complex notational figures, such as
-                notes, chords, beams, or tuplets, groups of characters can act as a single <a>logical unit</a>.
+                While the key signature is an optional field, the absence of a key signature in the
+                encoding can be ambiguous. It may be interpreted either as a completely natural key signature (i.e.,
+                C major) or it may indicate that a key signature was missing entirely from the original source.
+                The presence of the <code>n</code> character can be used to explicitly mark a key signature with no
+                sharps or flats. For sources where no key signature is needed, it is recommended to use
+                the <code>n</code> key signature to make this encoding explicit.
             </p>
-            <p>
-                A musical note is the most complex logical unit. It consists of one or more characters representing
-                a note on a musical staff. Many characters representing a note are optional—the only required character
-                is the note name—but where one or more characters for a note occurs, they MUST occur in the following order:
-            </p>
-            <table class="data">
-                <colgroup class="header"></colgroup>
-                <colgroup span="2"></colgroup>
+        </aside>
+        <p>
+            For neume notation, the key signature MUST be omitted. Any alterations to individual pitches MUST
+            be encoded as accidentals.
+        </p>
+        <aside class="example" title="Encoding Key Signatures">
+            <table class="simple" style="width:100%">
                 <thead>
-                    <tr>
-                        <th>Note Feature</th>
-                        <th>Characters</th>
-                        <th>Requirement</th>
-                    </tr>
+                <tr>
+                    <th>Code</th>
+                    <th>Notation</th>
+                    <th>Remarks</th>
+                </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Grace Note</td>
-                        <td><code>[qg]</code></td>
-                        <td>Optional</td>
-                    </tr>
-                    <tr>
-                        <td>Octave</td>
-                        <td><code>[,']</code></td>
-                        <td>Optional</td>
-                    </tr>
-                    <tr>
-                        <td>Duration / Duration Dot</td>
-                        <td><code>[0-9][.]</code></td>
-                        <td>Optional</td>
-                    </tr>
-                    <tr>
-                        <td>Accidental</td>
-                        <td><code>[xb]</code></td>
-                        <td>Optional</td>
-                    </tr>
-                    <tr>
-                        <td>Fermata</td>
-                        <td><code>[p]</code></td>
-                        <td>Optional</td>
-                    </tr>
-                    <tr>
-                        <td>Note Name</td>
-                        <td><code>[A-G]</code></td>
-                        <td><strong>Required</strong></td>
-                    </tr>
-                    <tr>
-                        <td>Trill</td>
-                        <td><code>[t]</code></td>
-                        <td>Optional</td>
-                    </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "C-1",
+                                "keysig": "xFC",
+                                "data": ""
+                            }
+                        </script>
+                        <code>xFC</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>F and C sharp (key is D major or B minor).</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "keysig": "bBEA",
+                                "data": ""
+                            }
+                        </script>
+                        <code>bBEA</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>B, E, A flat (key is E-flat major or C minor).</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "keysig": "bB[EA]",
+                                "data": ""
+                            }
+                        </script>
+                        <code>bB[EA]</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>The E and A flats in the key signature have been supplied by the <a>transcriber</a>.</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "keysig": "n",
+                                "data": ""
+                            }
+                        </script>
+                        <code>n</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>The natural key signature with no accidentals.</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "keysig": "xF[C]G[D]",
+                                "data": ""
+                            }
+                        </script>
+                        <code>xF[C]G[D]</code>
+                    </td>
+                    <td class="notation-result"></td>
+                    <td>F, C, G, and D sharp. The C and D are marked as supplied by the <a>transcriber</a>.</td>
+                </tr>
                 </tbody>
-                <caption>Order of characters representing a note</caption>
             </table>
+        </aside>
+    </section>
+    <section>
+        <div class="issue" data-number="64"></div>
+        <div class="issue" data-number="70"></div>
+        <div class="issue" data-number="71"></div>
+        <div class="issue" data-number="73"></div>
+        <div class="issue" data-number="103"></div>
+        <h4>Time Signature</h4>
+        <p>
+            An encoding MAY include a time signature.
+        </p>
+        <p>
+            There are two main categories of time signature forms, <a>Common Western Music Notation</a>
+            (<abbr title="Common Western Music Notation">CWMN</abbr>) and Mensural.
+        </p>
+        <p>
+            For neume notation, the time signature MUST be omitted.
+        </p>
+        <p>
+            <abbr title="Common Western Music Notation">CWMN</abbr> and Mensural time signatures MUST NOT
+            be mixed on the same staff.
+        </p>
+        <p>
+            <abbr title="Common Western Music Notation">CWMN</abbr> time signatures are expressed as one number
+            above another. These numbers MUST be separated by a <code>/</code> character. Any positive digit MAY
+            be used, but <a>encoders</a> SHOULD use commonly accepted values where possible. The <code>c</code>
+            ("common", or <code>4/4</code>) and <code>c/</code> ("alla breve", or <code>2/4</code>) characters
+            MAY be used.
+        </p>
+        <p>
+            <abbr title="Common Western Music Notation">CWMN</abbr> time signatures that indicate alternating
+            measures MAY be indicated by transcribing both. These MUST be separated by a vertical bar
+            <code>|</code> character.
+        </p>
+        <p>
+            For mensuration signs, the <code>c</code> and <code>o</code> characters indicate <em>tempus
+            imperfectus</em> and <em>tempus perfectus</em>, respectively. The <code>.</code> character indicates
+            "major" prolation; omitting <code>.</code> indicates "minor" prolation. A <code>/</code> character may
+            follow the <em>tempus</em> character to indicate diminution.
+        </p>
+        <p>
+            A mensuration sign MAY include a numerical component as a proportion or augmentation,
+            indicating <em>Modus cum tempore</em>. These numerals MUST be either a <code>3</code> or <code>2</code>.
+            These numbers MAY be combined and separated by a <code>/</code>.
+        </p>
+        <aside class="example" title="Encoding Time Signatures and Mensuration Signs">
+            <table class="simple" style="width: 100%">
+                <thead>
+                <tr>
+                    <th>Code</th>
+                    <th>Notation</th>
+                    <th>Remarks</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "timesig": "2/4",
+                                "data": ""
+                            }
+                        </script>
+                        <code>2/4</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td></td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "timesig": "12/16",
+                                "data": ""
+                            }
+                        </script>
+                        <code>12/16</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td></td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "timesig": "c",
+                                "data": ""
+                            }
+                        </script>
+                        <code>c</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td>common time</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "timesig": "c/",
+                                "data": ""
+                            }
+                        </script>
+                        <code>c/</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td><i>alla breve</i></td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "C+3",
+                                "timesig": "o",
+                                "data": ""
+                            }
+                        </script>
+                        <code>o</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td>Perfect <em>tempus</em>, minor prolation</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "C+3",
+                                "timesig": "o.",
+                                "data": ""
+                            }
+                        </script>
+                        <code>o.</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td>Perfect <em>tempus</em>, major prolation</td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "C+3",
+                                "timesig": "c3",
+                                "data": ""
+                            }
+                        </script>
+                        <code>c3</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td>Perfect <em>tempus</em>, imperfect minor <em>modus</em></td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "C+3",
+                                "timesig": "c2",
+                                "data": ""
+                            }
+                        </script>
+                        <code>c2</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td>Imerfect <em>tempus</em>, imperfect minor <em>modus</em></td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G+2",
+                                "timesig": "c/",
+                                "data": ""
+                            }
+                        </script>
+                        <code>c/</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td>With <em>diminution</em></td>
+                </tr>
+                <tr class="notation-example">
+                    <td class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "timesig": "3/4|4/4",
+                                "data": ""
+                            }
+                        </script>
+                        <code>3/4|4/4</code>
+                    </td>
+                    <td class="notation-result">
+                    </td>
+                    <td><i>Not currently supported by Verovio</i></td>
+                </tr>
+                </tbody>
+            </table>
+        </aside>
+    </section>
+</section>
+<section>
+    <h2>Musical Notation</h2>
+    <div class="issue" data-number="24"></div>
+    <div class="issue" data-number="97"></div>
+    <section>
+        <h4>Structure</h4>
+        <p>
+            The Musical Notation section of an encoding is given as a single line of characters. These characters
+            represent a staff of musical notation. To represent complex notational figures, such as
+            notes, chords, beams, or tuplets, groups of characters can act as a single <a>logical unit</a>.
+        </p>
+        <p>
+            A musical note is the most complex logical unit. It consists of one or more characters representing
+            a note on a musical staff. Many characters representing a note are optional—the only required character
+            is the note name—but where one or more characters for a note occurs, they MUST occur in the following order:
+        </p>
+        <table class="data">
+            <colgroup class="header"></colgroup>
+            <colgroup span="2"></colgroup>
+            <thead>
+                <tr>
+                    <th>Note Feature</th>
+                    <th>Characters</th>
+                    <th>Requirement</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Grace Note</td>
+                    <td><code>[qg]</code></td>
+                    <td>Optional</td>
+                </tr>
+                <tr>
+                    <td>Octave</td>
+                    <td><code>[,']</code></td>
+                    <td>Optional</td>
+                </tr>
+                <tr>
+                    <td>Duration / Duration Dot</td>
+                    <td><code>[0-9][.]</code></td>
+                    <td>Optional</td>
+                </tr>
+                <tr>
+                    <td>Accidental</td>
+                    <td><code>[xb]</code></td>
+                    <td>Optional</td>
+                </tr>
+                <tr>
+                    <td>Fermata</td>
+                    <td><code>[p]</code></td>
+                    <td>Optional</td>
+                </tr>
+                <tr>
+                    <td>Note Name</td>
+                    <td><code>[A-G]</code></td>
+                    <td><strong>Required</strong></td>
+                </tr>
+                <tr>
+                    <td>Trill</td>
+                    <td><code>[t]</code></td>
+                    <td>Optional</td>
+                </tr>
+            </tbody>
+            <caption>Order of characters representing a note</caption>
+        </table>
+        <p>
+            Logical units MAY be nested to represent complex notational features; for example, a beam will
+            contain two or more notes. All logical units of the same kind MUST be closed before a new one is
+            started (i.e., no nested groups of the same kind).
+        </p>
+        <aside class="note">
             <p>
-                Logical units MAY be nested to represent complex notational features; for example, a beam will
-                contain two or more notes. All logical units of the same kind MUST be closed before a new one is
-                started (i.e., no nested groups of the same kind).
+                There is one exception to this nested groups requirement: A group of beamed notes marked as grace notes can
+                occur within an outer beaming group. This is explained further in the beaming section.
             </p>
-            <aside class="note">
-                <p>
-                    There is one exception to this nested groups requirement: A group of beamed notes marked as grace notes can
-                    occur within an outer beaming group. This is explained further in the beaming section.
-                </p>
-            </aside>
-            <p>
-                Many logical units use the same character(s) to represent the same musical concept. Notes and rests,
-                for example, both make use of the same duration character(s).
-            </p>
-            <p>
-                There MUST be no spaces within the Musical Notation section. The only time a space MAY occur is to separate
-                a change of Clef, Key Signature, or Time Signature.
-            </p>
-        </section>
-        <section id="note-names">
-            <h4>Note Names</h4>
-            <p>
-                A note name MUST be provided to indicate the pitch class of the note.
-            </p>
-            <p>
-                Note names MUST be one of the following characters:
-                <code>C</code>, <code>D</code>, <code>E</code>, <code>F</code>,
-                <code>G</code>, <code>A</code>, <code>B</code>.
-            </p>
-            <p>
-                All letters MUST be uppercase; lowercase letters MUST NOT be used.
-            </p>
-            <aside class="example">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "CDEFGAB"
-                                }
-                            </script>
-                            <code>CDEFGAB</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Note names for a single octave.</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Octaves</h4>
-            <p>
-                Octaves in Plaine &amp; Easie are enumerated according to [[ScientificPitch]]. The boundary note
-                between octaves is C.
-            </p>
-            <p>
-                Octaves MUST be indicated using the apostrophe <code>'</code> for octave C4 and above, and the comma
-                <code>,</code> for octaves C3 and below. These characters are repeated to indicate successively
-                higher or lower octaves: <code>''</code> indicates C5, <code>'''</code> indicates C6, <code>,,</code>
-                indicates C2, and so on.
-            </p>
-            <p>
-                The number of apostrophes MUST NOT exceed four, corresponding to C7. The number of commas MUST NOT
-                exceed three, corresponding to C1.
-            </p>
-            <p>
-                The octave indication for a given note MAY be omitted. If the octave is omitted, the last specified
-                octave indication is used for all following notes.
-            </p>
-            <p>
-                An <a>encoding</a> MAY omit all octave indications. If no octave is supplied on any note, all notes are
-                assumed to be in octave C4.
-            </p>
-            <aside class="example" title="Encoding Octaves">
-                <table class="simple" style="width: 100%;">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example ignore">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'C''B"
-                                }
-                            </script>
-                            <code>'C''B</code>
-                        </td>
-                        <td class="notation-result ignore"></td>
-                        <td>octave C4-B5</td>
-                    </tr>
-                    <tr class="notation-example ignore">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "F-4",
-                                    "data": ",,C,B"
-                                }
-                            </script>
-                            <code>,,C,B</code>
-                        </td>
-                        <td class="notation-result ignore"></td>
-                        <td>octave C2-B3</td>
-                    </tr>
-                    <tr class="notation-example ignore">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "''C'GC,GC,,G"
-                                }
-                            </script>
-                            <code>''C'GC,GC,,G</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Octaves using ' and ,</td>
-                    </tr>
-                    <tr class="notation-example ignore">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'AB''CDC'BA"
-                                }
-                            </script>
-                            <code>AB''CDC'BA</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Using the last-specified octave indication.</td>
-                    </tr>
-                    <tr class="notation-example ignore">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "ABCD"
-                                }
-                            </script>
-                            <code>ABCD</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>No octave indication on any note (All notes in the 4th octave).</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
+        </aside>
+        <p>
+            Many logical units use the same character(s) to represent the same musical concept. Notes and rests,
+            for example, both make use of the same duration character(s).
+        </p>
+        <p>
+            There MUST be no spaces within the Musical Notation section. The only time a space MAY occur is to separate
+            a change of Clef, Key Signature, or Time Signature.
+        </p>
+    </section>
+    <section>
+        <h3>Notes and Rests</h3>
         <section>
             <div class="issue" data-number="39"></div>
             <h4>Durations</h4>
@@ -1132,6 +989,149 @@
             </aside>
         </section>
         <section>
+            <h4>Note Names</h4>
+            <p>
+                A note name MUST be provided to indicate the pitch class of the note.
+            </p>
+            <p>
+                Note names MUST be one of the following characters:
+                <code>C</code>, <code>D</code>, <code>E</code>, <code>F</code>,
+                <code>G</code>, <code>A</code>, <code>B</code>.
+            </p>
+            <p>
+                All letters MUST be uppercase; lowercase letters MUST NOT be used.
+            </p>
+            <aside class="example">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "CDEFGAB"
+                                }
+                            </script>
+                            <code>CDEFGAB</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Note names for a single octave.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Octaves</h4>
+            <p>
+                Octaves in Plaine &amp; Easie are enumerated according to [[ScientificPitch]]. The boundary note
+                between octaves is C.
+            </p>
+            <p>
+                Octaves MUST be indicated using the apostrophe <code>'</code> for octave C4 and above, and the comma
+                <code>,</code> for octaves C3 and below. These characters are repeated to indicate successively
+                higher or lower octaves: <code>''</code> indicates C5, <code>'''</code> indicates C6, <code>,,</code>
+                indicates C2, and so on.
+            </p>
+            <p>
+                The number of apostrophes MUST NOT exceed four, corresponding to C7. The number of commas MUST NOT
+                exceed three, corresponding to C1.
+            </p>
+            <p>
+                The octave indication for a given note MAY be omitted. If the octave is omitted, the last specified
+                octave indication is used for all following notes.
+            </p>
+            <p>
+                An <a>encoding</a> MAY omit all octave indications. If no octave is supplied on any note, all notes are
+                assumed to be in octave C4.
+            </p>
+            <aside class="example" title="Encoding Octaves">
+                <table class="simple" style="width: 100%;">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example ignore">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'C''B"
+                                }
+                            </script>
+                            <code>'C''B</code>
+                        </td>
+                        <td class="notation-result ignore"></td>
+                        <td>octave C4-B5</td>
+                    </tr>
+                    <tr class="notation-example ignore">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "F-4",
+                                    "data": ",,C,B"
+                                }
+                            </script>
+                            <code>,,C,B</code>
+                        </td>
+                        <td class="notation-result ignore"></td>
+                        <td>octave C2-B3</td>
+                    </tr>
+                    <tr class="notation-example ignore">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "''C'GC,GC,,G"
+                                }
+                            </script>
+                            <code>''C'GC,GC,,G</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Octaves using ' and ,</td>
+                    </tr>
+                    <tr class="notation-example ignore">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'AB''CDC'BA"
+                                }
+                            </script>
+                            <code>AB''CDC'BA</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Using the last-specified octave indication.</td>
+                    </tr>
+                    <tr class="notation-example ignore">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "ABCD"
+                                }
+                            </script>
+                            <code>ABCD</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>No octave indication on any note (All notes in the 4th octave).</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
             <h4>Accidentals</h4>
             <p>
                 An accidental MAY be used to alter the written and sounding pitch of a note. Accidentals MUST
@@ -1227,7 +1227,7 @@
             <p>
                 A note altered by an accidental SHOULD NOT be altered subsequent times within the same bar. The
                 alteration to the sounding pitch of the note is continued on subsequent notes with the same name
-                until the next <a>bar line</a>.
+                until the next <a href="#bar-lines">Bar Line</a>.
             </p>
             <p>
                 Accidentals MUST be interpreted by their written value, and MUST NOT be interpreted by their values
@@ -1243,29 +1243,214 @@
             </aside>
         </section>
         <section>
-            <h4>Rests</h4>
+            <h4>Trill</h4>
+            <p>
+                The lower-case character <code>t</code> is used to indicate
+                a trilled note. The <code>t</code> MUST immediately follow the
+                note name.
+            </p>
+            <aside class="example">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2Gt'1C"
+                                }
+                            </script>
+                            <code>2Gt</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Fermata</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Fermata</h4>
+            <p>
+                The lower-case character <code>p</code> is used to indicate
+                a fermata on a note. The <code>p</code> MUST immediately precede the
+                note name, and MUST follow any other attributes on the note that
+                occur before the note name.
+            </p>
+            <aside class="example">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2G1(C)"
+                                }
+                            </script>
+                            <code>2G1''pC</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Fermata</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <div class="issue" data-number="28"></div>
+            <h4>Ties</h4>
+            <p>
+                Tied notes MUST be indicated with an underscore character <code>_</code>.
+                Ties MUST occur between successive notes with the same pitch and octave.
+                A tie MUST NOT occur between a note and a rest.
+            </p>
+            <p>
+                The underscore character MUST occur on the first note of the tie.
+            <p>
+            <p>
+                Tied notes MAY occur over bar lines.
+            </p>
+            <p>
+                The underscore character MUST NOT be used to indicate slurs, phrase
+                marks, or ligatures.
+            </p>
+            <aside class="example" title="Encoding Ties">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "FG+GA"
+                                }
+                            </script>
+                            <code>FG_GA</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Tied notes within a bar</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2''G+/G"
+                                }
+                            </script>
+                            <code>2''G_/G</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Tied notes over a bar line</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "1''G+/G+/G"
+                                }
+                            </script>
+                            <code>2''G_/G_/G</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Successive tied notes</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+        <h4>Grace Notes</h4>
+            <p>
+                There are two types of grace note: Acciaccatura and appogiatura.
+            </p>
+            <p>
+                For a single acciaccatura the lower-case character <code>g</code>
+                MUST be used. This character MUST be specified in the order given above;
+                that is, it MUST precede the note name, and MUST also precede all other
+                optional attributes of the note. Consecutive single acciaccatura
+                SHOULD NOT occur.
+            </p>
+            <p>
+                For a single appogiatura note, the lower-case character <code>q</code>
+                MUST be used. This character MUST be specified in the order given above;
+                that is, it MUST precede the note name, and MUST also precede all other
+                optional attributes of the note.
+            </p>
+            <p>
+                Multple appogiatura notes SHOULD be encoded using an <a href="#appogiatura-group">
+                Appogiatura Group</a>. Consecutive single appogiatura SHOULD NOT occur.
+            </p>
+            <aside class="example" title="Encoding Grace Notes">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'4Ag''C{''8D'8B}"
+                                }
+                            </script>
+                            <code>'4Ag''C{''8D'8B}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Acciaccatura</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'4Aq8'B{'8A'8G}"
+                                }
+                            </script>
+                            <code>'4Aq8'B{'8A'8G}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Appoggiatura</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Single Rests</h4>
             <p>
                 Rests for single notes MUST be indicated by a hyphen/minus character <code>-</code>. This character
-                MAY be preceded by a <a>duration</a> value giving the musical duration of the rest. If the duration
-                is omitted, the last specified duration is used. If no duration is supplied in the <a>encoding</a>
-                a default duration of <code>4</code> is assumed.
-            </p>
-            <p>
-                Measure rests MUST be indicated by an equal sign character <code>=</code>. This character MUST be
-                followed by a non-negative integer indicating the number of measures for which this rest applies,
-                unless the measure rest only applies to a single measure. In this case, the number MAY be omitted.
-            </p>
-            <p>
-                Measure rests MUST be followed by a <a>bar line</a> character.
-            </p>
-            <p>
-                Measure rests MUST NOT be used with Mensural notation, due to the general absence of measures in
-                this notation.
-            </p>
-            <p>
-                Measure rests MAY indicate the number of measures that are being skipped in the
-                <a>original source</a> before the musical content being captured by the incipit, regardless of whether
-                these measures in the original source contain musical content.
+                MAY be preceded by a <a href="#duration">duration</a> value giving the musical duration of the rest.
+                If the duration is omitted, the last specified duration is used. If no duration is supplied in the
+                <a>encoding</a> a default duration of <code>4</code> is assumed.
             </p>
             <aside class="example" title="Encoding Rests">
                 <table class="simple" style="width: 100%">
@@ -1303,71 +1488,15 @@
                         <td class="notation-result"></td>
                         <td>Half-note rest</td>
                     </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "=/"
-                                }
-                            </script>
-                            <code>=/</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Single measure rest</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "=35/"
-                                }
-                            </script>
-                            <code>=35/</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>35 measures rest</td>
-                    </tr>
                     </tbody>
                 </table>
             </aside>
         </section>
+    </section>
+    <section>
+        <h3>Groups</h3>
         <section>
-            <h4>Chords</h4>
-            <div class="issue" data-number="2"></div>
-            <div class="issue" data-number="60"></div>
-            <div class="issue" data-number="65"></div>
-            <p>
-                Enter chords from the highest to the lowest note, each one separated by <code>^</code>.
-            </p>
-            <aside class="example" title="Encoding Chords">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "''2D^'A^xF"
-                                }
-                            </script>
-                            <code>''2D^'A^xF</code>
-                        </td>
-                        <td class="notation-result"></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Beaming</h4>
+            <h4>Beams</h4>
             <div class="issue" data-number="24"></div>
             <p>
                 Beamed notes are encoded using braces <code>{}</code>.
@@ -1375,7 +1504,7 @@
             <p>
                 Beam groups MUST start with an opening brace <code>{</code>, and
                 MUST end with a closing brace, <code>}</code>. Nested beam groups
-                MUST NOT occur, except as part of a <a>grace note group</a>.
+                MUST NOT occur, except as part of an <a href="#appogiatura-group">Appogiatura Group</a>.
             </p>
             <p>
                 Notes with duration values of <code>0</code>, <code>1</code>, <code>2</code>,
@@ -1428,6 +1557,179 @@
                 </table>
             </aside>
         </section>
+        <section>
+            <h4>Tuplets</h4>
+            <p>
+                A tuplet group MUST begin with a duration value to indicate the duration
+                of the tuplet group.
+            </p>
+            <p>
+                All musical symbols MAY occur within a tuplet group. The members of the tuplet
+                group MUST be enclosed within parentheses <code>()</code>.
+            </p>
+            <p>
+                The duration value MUST be provided for the first note or rest after the
+                opening parenthesis <code>(</code>.
+            </p>
+            <p>
+                A semicolon <code>;</code> and a non-negative integer MAY immediately precede
+                the closing parenthesis of a tuplet group. This number indicates the number of
+                beat divisions in the group; that is, the number of beats that occur within
+                the tuplet in the space of the given duration value. If a number is not
+                given, a value of <code>3</code> is the default.
+            </p>
+            <p>
+                A special encoding shortcut is available for <a href="#triplets">Triplets</a>.
+            </p>
+            <aside class="example" title="Encoding Special Rhythmic Groupings">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "timesig": "c",
+                                    "data": "4('6DEFGA;5)/"
+                                }
+                            </script>
+                            <code>4('6DEFGA;5)</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Quintuplet, 5 16th notes, in the space of a quarter note</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "timesig": "c",
+                                    "data": "8({'3DEFGA};5)/"
+                                }
+                            </script>
+                            <code>8({'3DEFGA};5)</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Quintuplet, 5 32nd notes, in the space of an eighth note, with beamed notes</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "timesig": "c",
+                                    "data": "4('4D8E)4('4D8E)/"
+                                }
+                            </script>
+                            <code>4('4D8E)4('4D8E)</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Two triplet values of varying duration.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Appogiatura Group</h4>
+            <p>
+                For multiple consecutive appogiatura notes, the appogiatura group SHOULD
+                be used. The lower-case characters <code>qq</code> MUST be given as the first
+                characters before the first note of the group, and the lower-case character
+                <code>r</code> MUST be the last character in the final note of the group.
+                There MUST be more than one note in a appogiatura group.
+            </p>
+            <p>
+                The <code>r</code> character MUST follow the closing beam character
+                that is part of the appogiatura group.
+            </p>
+            <p>
+                An appogiatura group with beams MAY occur within a non-appogiatura
+                beam.
+            </p>
+            <aside class="example" title="Encoding Appogiatura Groups">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'4Aqq''{'8B''8C}r{''8D'8B}"
+                                }
+                            </script>
+                            <code>'4Aqq''{'8B''8C}r{''8D'8B}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Appoggiatura group</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "{'8Aqq''{'8B''8C}r''8D}"
+                                }
+                            </script>
+                            <code>{'8Aqq''{'8B''8C}r''8D}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Beamed appoggiatura group within an outer beam</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Chords</h4>
+            <div class="issue" data-number="2"></div>
+            <div class="issue" data-number="60"></div>
+            <div class="issue" data-number="65"></div>
+            <p>
+                Enter chords from the highest to the lowest note, each one separated by <code>^</code>.
+            </p>
+            <aside class="example" title="Encoding Chords">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "''2D^'A^xF"
+                                }
+                            </script>
+                            <code>''2D^'A^xF</code>
+                        </td>
+                        <td class="notation-result"></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+    </section>
+    <section>
+        <h3>Staff Symbols</h3>
         <section>
             <h4>Bar Lines</h4>
             <div class="issue" data-number="44"></div>
@@ -1589,30 +1891,25 @@
             </aside>
         </section>
         <section>
-            <h4>Tuplets</h4>
+            <h4>Measure Rests</h4>
             <p>
-                A tuplet group MUST begin with a duration value to indicate the duration
-                of the tuplet group.
+                Measure rests MUST be indicated by an equal sign character <code>=</code>. This character MUST be
+                followed by a non-negative integer indicating the number of measures for which this rest applies,
+                unless the measure rest only applies to a single measure. In this case, the number MAY be omitted.
             </p>
             <p>
-                All musical symbols MAY occur within a tuplet group. The members of the tuplet
-                group MUST be enclosed within parentheses <code>()</code>.
+                Measure rests MUST be followed by a <a href="#bar-lines">bar line</a> character.
             </p>
             <p>
-                The duration value MUST be provided for the first note or rest after the
-                opening parenthesis <code>(</code>.
+                Measure rests MUST NOT be used with Mensural notation, due to the general absence of measures in
+                this system of notation.
             </p>
             <p>
-                A semicolon <code>;</code> and a non-negative integer MAY immediately precede
-                the closing parenthesis of a tuplet group. This number indicates the number of
-                beat divisions in the group; that is, the number of beats that occur within
-                the tuplet in the space of the given duration value. If a number is not
-                given, a value of <code>3</code> is the default.
+                Measure rests MAY indicate the number of measures that are being skipped in the
+                <a>original source</a> before the musical content being captured by the incipit, regardless of whether
+                these measures in the original source contain musical content.
             </p>
-            <p>
-                A special encoding shortcut is available for <a>triplets</a>.
-            </p>
-            <aside class="example" title="Encoding Special Rhythmic Groupings">
+            <aside class="example" title="Encoding Rests">
                 <table class="simple" style="width: 100%">
                     <thead>
                     <tr>
@@ -1627,437 +1924,30 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "timesig": "c",
-                                    "data": "4('6DEFGA;5)/"
+                                    "data": "=/"
                                 }
                             </script>
-                            <code>4('6DEFGA;5)</code>
+                            <code>=/</code>
                         </td>
                         <td class="notation-result"></td>
-                        <td>Quintuplet, 5 16th notes, in the space of a quarter note</td>
+                        <td>Single measure rest</td>
                     </tr>
                     <tr class="notation-example">
                         <td class="notation-code">
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "timesig": "c",
-                                    "data": "8({'3DEFGA};5)/"
+                                    "data": "=35/"
                                 }
                             </script>
-                            <code>8({'3DEFGA};5)</code>
+                            <code>=35/</code>
                         </td>
                         <td class="notation-result"></td>
-                        <td>Quintuplet, 5 32nd notes, in the space of an eighth note, with beamed notes</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "timesig": "c",
-                                    "data": "4('4D8E)4('4D8E)/"
-                                }
-                            </script>
-                            <code>4('4D8E)4('4D8E)</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Two triplet values of varying duration.</td>
+                        <td>35 measures rest</td>
                     </tr>
                     </tbody>
                 </table>
             </aside>
-        </section>
-        <section>
-            <div class="issue" data-number="28"></div>
-            <h4>Tied Notes</h4>
-            <p>
-                Tied notes MUST be indicated with an underscore character <code>_</code>.
-                Ties MUST occur between successive notes with the same pitch and octave.
-                A tie MUST NOT occur between a note and a rest.
-            </p>
-            <p>
-                The underscore character MUST occur on the first note of the tie.
-            <p>
-            <p>
-                Tied notes MAY occur over bar lines.
-            </p>
-            <p>
-                The underscore character MUST NOT be used to indicate slurs, phrase
-                marks, or ligatures.
-            </p>
-            <aside class="example" title="Encoding Ties">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "FG+GA"
-                                }
-                            </script>
-                            <code>FG_GA</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Tied notes within a bar</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "2''G+/G"
-                                }
-                            </script>
-                            <code>2''G_/G</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Tied notes over a bar line</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "1''G+/G+/G"
-                                }
-                            </script>
-                            <code>2''G_/G_/G</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Successive tied notes</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Grace Notes</h4>
-            <p>
-                There are two types of grace note: Acciaccatura and appogiatura.
-            </p>
-            <p>
-                For a single acciaccatura the lower-case character <code>g</code>
-                MUST be used. This character MUST be specified in the order given above;
-                that is, it MUST precede the note name, and MUST also precede all other
-                optional attributes of the note. Consecutive single acciaccatura
-                SHOULD NOT occur.
-            </p>
-            <p>
-                For a single appogiatura note, the lower-case character <code>q</code>
-                MUST be used. This character MUST be specified in the order given above;
-                that is, it MUST precede the note name, and MUST also precede all other
-                optional attributes of the note. Consecutive single appogiatura
-                SHOULD NOT occur.
-            </p>
-            <section>
-                <h5>Appogiatura Group</h5>
-                <p>
-                    For multiple consecutive appogiatura notes, the appogiatura group SHOULD
-                    be used. The lower-case characters <code>qq</code> MUST be given as the first
-                    characters before the first note of the group, and the lower-case character
-                    <code>r</code> MUST be the last character in the final note of the group.
-                    There MUST be more than one note in a appogiatura group.
-                </p>
-                <p>
-                    The <code>r</code> character MUST follow the closing beam character
-                    that is part of the appogiatura group.
-                </p>
-                <p>
-                    An appogiatura group with beams MAY occur within a non-appogiatura
-                    beam.
-                </p>
-            </section>
-            <aside class="example" title="Encoding Grace Notes">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'4Ag''C{''8D'8B}"
-                                }
-                            </script>
-                            <code>'4Ag''C{''8D'8B}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Acciaccatura</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'4Aq8'B{'8A'8G}"
-                                }
-                            </script>
-                            <code>'4Aq8'B{'8A'8G}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Appoggiatura</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'4Aqq''{'8B''8C}r{''8D'8B}"
-                                }
-                            </script>
-                            <code>'4Aqq''{'8B''8C}r{''8D'8B}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Appoggiatura group</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "{'8Aqq''{'8B''8C}r''8D}"
-                                }
-                            </script>
-                            <code>{'8Aqq''{'8B''8C}r''8D}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Beamed appoggiatura group within an outer beam</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Trill</h4>
-            <p>
-                The lower-case character <code>t</code> is used to indicate
-                a trilled note. The <code>t</code> MUST immediately follow the
-                note name.
-            </p>
-            <aside class="example">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "2Gt'1C"
-                                }
-                            </script>
-                            <code>2Gt</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Fermata</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Fermata</h4>
-            <p>
-                The lower-case character <code>p</code> is used to indicate
-                a fermata on a note. The <code>p</code> MUST immediately precede the
-                note name, and MUST follow any other attributes on the note that
-                occur before the note name.
-            </p>
-            <aside class="example">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "2G1(C)"
-                                }
-                            </script>
-                            <code>2G1''pC</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Fermata</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Shortcuts</h4>
-            <section>
-                <h5>Repeat group</h5>
-                <p>
-                    If one or notes or rests are repeated several times, a repeat group
-                    MAY be used.
-                </p>
-                <p>
-                    A repeat group is only valid within a single measure.
-                <p>
-                <p>
-                    To use a repeat group, mark the beginning and the end of the group with
-                    an exclamation mark character <code>!</code>. The lower-case character
-                    <code>f</code> MUST immediately follow the ending <code>!</code>, and
-                    MUST occur the number of times the figure should be repeated. The
-                    <code>f</code> MUST be specified at least once.
-                </p>
-                <aside class="example" title="Encoding Repeated Figures">
-                    <table class="simple" style="width: 100%">
-                        <thead>
-                        <tr>
-                            <th>Code</th>
-                            <th>Notation</th>
-                            <th>Remarks</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "timesig": "3/2",
-                                        "data": "!{'8ABAG}!ff"
-                                    }
-                                </script>
-                                <code>!{'8ABAG}!ff</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Repeat twice</td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </aside>
-            </section>
-            <section>
-                <h5>Repeated measures</h5>
-                <p>
-                    If one or more whole measures are repeated, a measure
-                    repeat MAY be used.
-                </p>
-                <p>
-                    The measure to be repeated MUST end with a bar line. The lower-case
-                    character <code>i</code> MUST occur immediately after this bar line,
-                    and MUST be immediately followed by another bar line. There MUST NOT
-                    be any other characters between the two bar lines.
-                </p>
-                <p>
-                    Any type of bar line MAY be used to begin or end a measure repeat group.
-                </p>
-                <p>
-                    Measure repeats SHOULD NOT be used with Mensural notation.
-                </p>
-                <aside class="example" title="Encoding Repeated Measures">
-                    <table class="simple" style="width: 100%">
-                        <thead>
-                        <tr>
-                            <th>Code</th>
-                            <th>Notation</th>
-                            <th>Remarks</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "timesig": "3/2",
-                                        "data": "'4ABAG/i/i/"
-                                    }
-                                </script>
-                                <code>'4ABAG/i/i/</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Repeat measure twice</td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </aside>
-            </section>
-            <section>
-                <h5>Rhythmic sequence</h5>
-                <p>
-                    When the same rhythmic sequence is repeated, the sequence of rhythmic values can be stated once
-                    before the note names.
-                </p>
-                <aside class="example" title="Encoding Rhythmic Sequences">
-                    <table class="simple" style="width: 100%">
-                        <thead>
-                        <tr>
-                            <th>Code</th>
-                            <th>Notation</th>
-                            <th>Remarks</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "timesig": "3/2",
-                                        "data": "'8.68{AB''C}{DEF}"
-                                    }
-                                </script>
-                                <code>'8.68{AB''C}{DEF}</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>
-                                instead of <code>{'8.A6B''8C}{8.D6E8F}</code> the code can be <code>'8.68{AB''C}{DEF}</code>.
-                                The rhythmic sequence ends when a new rhythmic value appears.
-                            </td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </aside>
-            </section>
-            <section>
-                <h5>Triplets</h5>
-                <p>
-                    The triplet is a special case; strictly speaking, it should be coded as follows:
-                </p>
-                <pre class="text">
-                    8(6ABC;3) or 8({6ABC};3)
-                </pre>
-                <p>
-                    Instead, the following shortcut is permitted:
-                </p>
-                <pre class="text">
-                    (6ABC) or ({6ABC})
-                </pre>
-                <p>
-                    The rhythmic value inside the parentheses is required.
-                </p>
-            </section>
         </section>
         <section>
             <h4>Change of Clef, Key Signature, Time Signature</h4>
@@ -2067,13 +1957,13 @@
             <p>
                 The percent character <code>%</code> MUST be used to indicate a clef change. A clef change MAY occur anywhere
                 within the music notation section. This character MUST be followed by a clef definition according
-                to the specifications given in the <a>Clefs</a> section.
+                to the specifications given in the <a href="#clef">Clef</a> section.
             </p>
             <p>
                 The dollar character <code>$</code> MUST be used to indicate a key signature change. A key signature
                 change MAY appear anywhere in the music notation, but SHOULD appear immediately following a
                 bar line. This character MUST be followed by a key signature definition according to the
-                specifications given in the <a>Key Signatures</a> section.
+                specifications given in the <a href="#key-signature">Key Signature</a> section.
             </p>
             <aside class="note">
                 <p>
@@ -2085,7 +1975,7 @@
                 The at sign character <code>@</code> MUST be used to indicate a time signature change. A time signature
                 change MAY appear anywhere in the music notation, but SHOULD appear immediately following a
                 bar line. This character MUST be followed by a time signature definition according to the
-                specifications given in the <a>Time Signatures</a> section.
+                specifications given in the <a href="#time-signature">Time Signature</a> section.
             </p>
             <p>
                 For any change of clef, key signature, time signature, or combination thereof, the change indication
@@ -2134,6 +2024,154 @@
                     </tbody>
                 </table>
             </aside>
+        </section>
+    </section>
+    <section>
+        <h4>Shortcuts</h4>
+        <section>
+            <h5>Repeat group</h5>
+            <p>
+                If one or notes or rests are repeated several times, a repeat group
+                MAY be used.
+            </p>
+            <p>
+                A repeat group is only valid within a single measure.
+            <p>
+            <p>
+                To use a repeat group, mark the beginning and the end of the group with
+                an exclamation mark character <code>!</code>. The lower-case character
+                <code>f</code> MUST immediately follow the ending <code>!</code>, and
+                MUST occur the number of times the figure should be repeated. The
+                <code>f</code> MUST be specified at least once.
+            </p>
+            <aside class="example" title="Encoding Repeated Figures">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "timesig": "3/2",
+                                    "data": "!{'8ABAG}!ff"
+                                }
+                            </script>
+                            <code>!{'8ABAG}!ff</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Repeat twice</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h5>Repeated measures</h5>
+            <p>
+                If one or more whole measures are repeated, a measure
+                repeat MAY be used.
+            </p>
+            <p>
+                The measure to be repeated MUST end with a bar line. The lower-case
+                character <code>i</code> MUST occur immediately after this bar line,
+                and MUST be immediately followed by another bar line. There MUST NOT
+                be any other characters between the two bar lines.
+            </p>
+            <p>
+                Any type of bar line MAY be used to begin or end a measure repeat group.
+            </p>
+            <p>
+                Measure repeats SHOULD NOT be used with Mensural notation.
+            </p>
+            <aside class="example" title="Encoding Repeated Measures">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "timesig": "3/2",
+                                    "data": "'4ABAG/i/i/"
+                                }
+                            </script>
+                            <code>'4ABAG/i/i/</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Repeat measure twice</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h5>Rhythmic sequence</h5>
+            <p>
+                When the same rhythmic sequence is repeated, the sequence of rhythmic values can be stated once
+                before the note names.
+            </p>
+            <aside class="example" title="Encoding Rhythmic Sequences">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "timesig": "3/2",
+                                    "data": "'8.68{AB''C}{DEF}"
+                                }
+                            </script>
+                            <code>'8.68{AB''C}{DEF}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>
+                            instead of <code>{'8.A6B''8C}{8.D6E8F}</code> the code can be <code>'8.68{AB''C}{DEF}</code>.
+                            The rhythmic sequence ends when a new rhythmic value appears.
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h5>Triplets</h5>
+            <p>
+                The triplet is a special case; strictly speaking, it should be coded as follows:
+            </p>
+            <pre class="text">
+                8(6ABC;3) or 8({6ABC};3)
+            </pre>
+            <p>
+                Instead, the following shortcut is permitted:
+            </p>
+            <pre class="text">
+                (6ABC) or ({6ABC})
+            </pre>
+            <p>
+                The rhythmic value inside the parentheses is required.
+            </p>
         </section>
     </section>
 </section>

--- a/v2/index.html
+++ b/v2/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8"/>
-    <meta name="color-scheme" content="light" />
+    <meta name="color-scheme" content="light"/>
     <title>Plaine &amp; Easie Code</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script src="https://www.verovio.org/javascript/latest/verovio-toolkit-wasm.js" defer></script>
@@ -47,11 +47,11 @@
             maxTocLevel: 4,
             logos: [
                 {
-                  src: "/static/img/pae-logo.svg",
-                  alt: "Plaine & Easie Code Logo",
-                  width: 200,
-                  // height: 42,
-                  id: "pae-logo",
+                    src: "/static/img/pae-logo.svg",
+                    alt: "Plaine & Easie Code Logo",
+                    width: 200,
+                    // height: 42,
+                    id: "pae-logo",
                 },
             ],
             localBiblio: {
@@ -77,11 +77,11 @@
                     rawDate: "December 2023"
                 },
                 "UNIMARC": {
-                  editors: ["Mazić, Gordana", "Badovinac, Branka"],
-                  title: "UNIMARC Bibliographic Format Manual",
-                  href: "https://repository.ifla.org/bitstream/123456789/2880/1/UNIMARC_B_ONLINE_V100_2023_PUBLISHED.pdf",
-                  publisher: "International Federation of Library Associations and Institutions",
-                  rawDate: "2023"
+                    editors: ["Mazić, Gordana", "Badovinac, Branka"],
+                    title: "UNIMARC Bibliographic Format Manual",
+                    href: "https://repository.ifla.org/bitstream/123456789/2880/1/UNIMARC_B_ONLINE_V100_2023_PUBLISHED.pdf",
+                    publisher: "International Federation of Library Associations and Institutions",
+                    rawDate: "2023"
                 },
                 "BrookGould1964": {
                     authors: ["Brook, Barry S.", "Gould, Murray"],
@@ -103,8 +103,7 @@
     <script type="application/javascript" src="/static/js/verovio-rendering.js"></script>
     <style>
         /* custom styles for inline code to make it stand out */
-        p code
-        {
+        p code {
             color: #c63501 !important;
             background: ghostwhite;
             padding: 2px 4px;
@@ -132,7 +131,7 @@
     </p>
 </section>
 <section id="introduction">
-    <h1>Introduction</h2>
+    <h2>Introduction</h2>
     <p>
         The Plaine &amp; Easie Code was first defined in 1964 by Barry S. Brook and Murray Gould
         [[BrookGould1964]][[Brook1965]]. Perhaps the most important design feature of this system
@@ -175,11 +174,13 @@
     </p>
     <p>
         The Plaine &amp; Easie Code is maintained by the Digial and Editorial Centers of the
-        Répertoire International des Sources Musicales (RISM), and by the International Association of Music Libraries,
-        Archives and Documentation Centres (IAML) for use as an exchange format in the library environment.
+        Répertoire International des Sources Musicales (RISM), and by the International Association of Music
+        Libraries, Archives and Documentation Centres (IAML) for use as an exchange format in the library environment.
     </p>
 </section>
 <section id="terminology">
+    <div class="issue" data-number="98"></div>
+    <div class="issue" data-number="117"></div>
     <h2>Terminology</h2>
     <dl>
         <dt><dfn>Circle of fifths</dfn></dt>
@@ -188,7 +189,8 @@
         <dd>The person or persons who transcribe the source into Plaine &amp; Easie.</dd>
         <dt><dfn>Logical Unit</dfn></dt>
         <dd>A logical unit of notation data consists of one or more characters that represent a single musical notation
-        figure.</dd>
+            figure.
+        </dd>
     </dl>
 </section>
 <section>
@@ -200,7 +202,8 @@
     </p>
     <section>
         <div class="issue" data-number="72"></div>
-        <h4>Clef</h4>
+        <div class="issue" data-number="119"></div>
+        <h3>Clef</h3>
         <p>
             Every encoding MUST include a clef.
         </p>
@@ -233,33 +236,33 @@
             <colgroup class="header"></colgroup>
             <colgroup span="2"></colgroup>
             <thead>
-                <tr>
-                    <th>Shape and Line</th>
-                    <th>Bottom Line Octave and Note</th>
-                    <th>Top Line Octave and Note</th>
-                </tr>
+            <tr>
+                <th>Shape and Line</th>
+                <th>Bottom Line Octave and Note</th>
+                <th>Top Line Octave and Note</th>
+            </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td><code>G-2</code></td>
-                    <td><code>'E</code> (E4)</td>
-                    <td><code>''F</code> (F5)</td>
-                </tr>
-                <tr>
-                    <td><code>F-4</code></td>
-                    <td><code>,,G</code> (G2)</td>
-                    <td><code>,A</code> (A3)</td>
-                </tr>
-                <tr>
-                    <td><code>g-2</code></td>
-                    <td><code>,E</code> (E3)</td>
-                    <td><code>'F</code> (F4)</td>
-                </tr>
-                <tr>
-                    <td><code>C-3</code></td>
-                    <td><code>,F</code> (F3)</td>
-                    <td><code>'G</note> (G4)</>
-                </tr>
+            <tr>
+                <td><code>G-2</code></td>
+                <td><code>'E</code> (E4)</td>
+                <td><code>''F</code> (F5)</td>
+            </tr>
+            <tr>
+                <td><code>F-4</code></td>
+                <td><code>,,G</code> (G2)</td>
+                <td><code>,A</code> (A3)</td>
+            </tr>
+            <tr>
+                <td><code>g-2</code></td>
+                <td><code>,E</code> (E3)</td>
+                <td><code>'F</code> (F4)</td>
+            </tr>
+            <tr>
+                <td><code>C-3</code></td>
+                <td><code>,F</code> (F3)</td>
+                <td><code>'G</note> (G4)</>
+            </tr>
             </tbody>
         </table>
         <aside class="example" title="Encoding Clefs">
@@ -342,7 +345,7 @@
         </aside>
     </section>
     <section>
-        <h4>Key Signature</h4>
+        <h3>Key Signature</h3>
         <p>
             An encoding MAY include a key signature.
         </p>
@@ -361,14 +364,14 @@
             <a>sounding pitch</a> indicated by the accidental will take precedence.
         </p>
         <p>
-            A key signature containing a single <code>n</code> character MAY be supplied to indicate a natural key
-            signature, i.e., C Major or A minor. This character MUST NOT be followed by any note names.
-        </p>
-        <p>
             A key signature MAY contain note names within square brackets <code>[]</code> to indicate that the
             note names are not in the original source and have been supplied by the <a>transcriber</a>. Consecutively
             supplied note names MUST be within a single set of brackets. A key signature MAY contain more than one
             set of non-consecutive bracket groups.
+        </p>
+        <p>
+            A key signature containing a single <code>n</code> character MAY be supplied to indicate a natural key
+            signature, i.e., C Major or A minor. This character MUST NOT be followed by any note names.
         </p>
         <aside class="note">
             <p>
@@ -469,12 +472,8 @@
         </aside>
     </section>
     <section>
-        <div class="issue" data-number="64"></div>
-        <div class="issue" data-number="70"></div>
-        <div class="issue" data-number="71"></div>
         <div class="issue" data-number="73"></div>
-        <div class="issue" data-number="103"></div>
-        <h4>Time Signature</h4>
+        <h3>Time Signature</h3>
         <p>
             An encoding MAY include a time signature.
         </p>
@@ -679,83 +678,71 @@
 </section>
 <section>
     <h2>Musical Notation</h2>
-    <div class="issue" data-number="24"></div>
     <div class="issue" data-number="97"></div>
     <section>
-        <h4>Structure</h4>
+        <h3>Structure</h3>
         <p>
-            The Musical Notation section of an encoding is given as a single line of characters. These characters
-            represent a staff of musical notation. To represent complex notational figures, such as
-            notes, chords, beams, or tuplets, groups of characters can act as a single <a>logical unit</a>.
+            The Musical Notation section of an encoding is given as a single line of characters representing
+            a <a>staff</a> of musical notation. <a>Notes and rests</a> are the most basic <a>logical unit</a>
+            of notation representation, composed of one or more characters that specify different attributes
+            of a note or rest symbol. Complex notational figures, such as chords, beams, or tuplets, serve
+            to <a>group</a> notes and rests. <a>Ornaments</a> alter the performance of a note, a rest, or
+            groups thereof. Other <a>staff and measure symbols</a> can control the definition of the staff
+            itself: bar lines, cross-measure rests, or a change of clef, key signature, or time signature.
         </p>
         <p>
-            A musical note is the most complex logical unit. It consists of one or more characters representing
-            a note on a musical staff. Many characters representing a note are optional—the only required character
-            is the note name—but where one or more characters for a note occurs, they MUST occur in the following order:
+            Many characters representing a musical note are optional—the only required character is the
+            note name. Where one or more characters for a note occurs, they MUST occur in the following order:
         </p>
         <table class="data">
             <colgroup class="header"></colgroup>
             <colgroup span="2"></colgroup>
             <thead>
-                <tr>
-                    <th>Note Feature</th>
-                    <th>Characters</th>
-                    <th>Requirement</th>
-                </tr>
+            <tr>
+                <th>Note Feature</th>
+                <th>Characters</th>
+                <th>Requirement</th>
+            </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>Grace Note</td>
-                    <td><code>[qg]</code></td>
-                    <td>Optional</td>
-                </tr>
-                <tr>
-                    <td>Octave</td>
-                    <td><code>[,']</code></td>
-                    <td>Optional</td>
-                </tr>
-                <tr>
-                    <td>Duration / Duration Dot</td>
-                    <td><code>[0-9][.]</code></td>
-                    <td>Optional</td>
-                </tr>
-                <tr>
-                    <td>Accidental</td>
-                    <td><code>[xb]</code></td>
-                    <td>Optional</td>
-                </tr>
-                <tr>
-                    <td>Fermata</td>
-                    <td><code>[p]</code></td>
-                    <td>Optional</td>
-                </tr>
-                <tr>
-                    <td>Note Name</td>
-                    <td><code>[A-G]</code></td>
-                    <td><strong>Required</strong></td>
-                </tr>
-                <tr>
-                    <td>Trill</td>
-                    <td><code>[t]</code></td>
-                    <td>Optional</td>
-                </tr>
+            <tr>
+                <td>Octave</td>
+                <td><code>[,']</code></td>
+                <td>Optional</td>
+            </tr>
+            <tr>
+                <td>Duration / Duration Dot</td>
+                <td><code>[0-9][.]</code></td>
+                <td>Optional</td>
+            </tr>
+            <tr>
+                <td>Accidental</td>
+                <td><code>[xb]</code></td>
+                <td>Optional</td>
+            </tr>
+            <tr>
+                <td>Note Name</td>
+                <td><code>[A-G]</code></td>
+                <td><strong>Required</strong></td>
+            </tr>
             </tbody>
             <caption>Order of characters representing a note</caption>
         </table>
         <p>
             Logical units MAY be nested to represent complex notational features; for example, a beam will
-            contain two or more notes. All logical units of the same kind MUST be closed before a new one is
-            started (i.e., no nested groups of the same kind).
+            contain two or more notes, or tuplet may be composed of two or more chords. All logical units
+            of the same kind MUST be closed before a new one is started (i.e., no nested groups of the same kind).
         </p>
         <aside class="note">
             <p>
-                There is one exception to this nested groups requirement: A group of beamed notes marked as grace notes can
-                occur within an outer beaming group. This is explained further in the beaming section.
+                There is one exception to this nested groups requirement: A group of notes marked as
+                an <a>appogiatura group</a> can occur within an outer group. This is explained further in
+                the <a>appogiatura group</a> section.
             </p>
         </aside>
         <p>
-            Many logical units use the same character(s) to represent the same musical concept. Notes and rests,
-            for example, both make use of the same duration character(s).
+            Many logical units use the same character(s) to represent the same musical concept. Both notes and rests,
+            for example, make use of the same duration character(s).
         </p>
         <p>
             There MUST be no spaces within the Musical Notation section. The only time a space MAY occur is to separate
@@ -765,7 +752,6 @@
     <section>
         <h3>Notes and Rests</h3>
         <section>
-            <div class="issue" data-number="39"></div>
             <h4>Durations</h4>
             <p>
                 Note durations MUST be represented by integer values in the range <code>0-9</code>. The corresponding
@@ -1142,78 +1128,78 @@
                     <colgroup class="header"></colgroup>
                     <colgroup span="2"></colgroup>
                     <thead>
-                        <tr>
-                            <th>Accidental</th>
-                            <th>Notation</th>
-                            <th>Remarks</th>
-                        </tr>
+                    <tr>
+                        <th>Accidental</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
                     </thead>
                     <tbody>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "xG"
-                                    }
-                                </script>
-                                <code>x</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>sharp</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "bB"
-                                    }
-                                </script>
-                                <code>b</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>flat</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "xxG"
-                                    }
-                                </script>
-                                <code>xx</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>double-sharp</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "bbB"
-                                    }
-                                </script>
-                                <code>bb</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>double-flat</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "nB"
-                                    }
-                                </script>
-                                <code>n</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>natural</td>
-                        </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "xG"
+                                }
+                            </script>
+                            <code>x</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>sharp</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "bB"
+                                }
+                            </script>
+                            <code>b</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>flat</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "xxG"
+                                }
+                            </script>
+                            <code>xx</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>double-sharp</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "bbB"
+                                }
+                            </script>
+                            <code>bb</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>double-flat</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "nB"
+                                }
+                            </script>
+                            <code>n</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>natural</td>
+                    </tr>
                     </tbody>
 
                 </table>
@@ -1243,13 +1229,14 @@
             </aside>
         </section>
         <section>
-            <h4>Trill</h4>
+            <h4>Single Rests</h4>
             <p>
-                The lower-case character <code>t</code> is used to indicate
-                a trilled note. The <code>t</code> MUST immediately follow the
-                note name.
+                Rests for single notes MUST be indicated by a hyphen/minus character <code>-</code>. This character
+                MAY be preceded by a <a href="#duration">duration</a> value giving the musical duration of the rest.
+                If the duration is omitted, the last specified duration is used. If no duration is supplied in the
+                <a>encoding</a> a default duration of <code>4</code> is assumed.
             </p>
-            <aside class="example">
+            <aside class="example" title="Encoding Rests">
                 <table class="simple" style="width: 100%">
                     <thead>
                     <tr>
@@ -1264,55 +1251,36 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2Gt'1C"
+                                    "data": "8-"
                                 }
                             </script>
-                            <code>2Gt</code>
+                            <code>8-</code>
                         </td>
                         <td class="notation-result"></td>
-                        <td>Fermata</td>
+                        <td>Eighth-note rest</td>
                     </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
-            <h4>Fermata</h4>
-            <p>
-                The lower-case character <code>p</code> is used to indicate
-                a fermata on a note. The <code>p</code> MUST immediately precede the
-                note name, and MUST follow any other attributes on the note that
-                occur before the note name.
-            </p>
-            <aside class="example">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
                     <tr class="notation-example">
                         <td class="notation-code">
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2G1(C)"
+                                    "data": "2-"
                                 }
                             </script>
-                            <code>2G1''pC</code>
+                            <code>2-</code>
                         </td>
                         <td class="notation-result"></td>
-                        <td>Fermata</td>
+                        <td>Half-note rest</td>
                     </tr>
                     </tbody>
                 </table>
             </aside>
         </section>
+    </section>
+    <section>
+        <h3>Groups</h3>
         <section>
-            <div class="issue" data-number="28"></div>
+            <div class="issue" data-number="112"></div>
             <h4>Ties</h4>
             <p>
                 Tied notes MUST be indicated with an underscore character <code>_</code>.
@@ -1383,121 +1351,14 @@
             </aside>
         </section>
         <section>
-        <h4>Grace Notes</h4>
+            <div class="issue" data-number="28"></div>
+            <h4>Ligatures</h4>
             <p>
-                There are two types of grace note: Acciaccatura and appogiatura.
+                Todo.
             </p>
-            <p>
-                For a single acciaccatura the lower-case character <code>g</code>
-                MUST be used. This character MUST be specified in the order given above;
-                that is, it MUST precede the note name, and MUST also precede all other
-                optional attributes of the note. Consecutive single acciaccatura
-                SHOULD NOT occur.
-            </p>
-            <p>
-                For a single appogiatura note, the lower-case character <code>q</code>
-                MUST be used. This character MUST be specified in the order given above;
-                that is, it MUST precede the note name, and MUST also precede all other
-                optional attributes of the note.
-            </p>
-            <p>
-                Multple appogiatura notes SHOULD be encoded using an <a href="#appogiatura-group">
-                Appogiatura Group</a>. Consecutive single appogiatura SHOULD NOT occur.
-            </p>
-            <aside class="example" title="Encoding Grace Notes">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'4Ag''C{''8D'8B}"
-                                }
-                            </script>
-                            <code>'4Ag''C{''8D'8B}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Acciaccatura</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'4Aq8'B{'8A'8G}"
-                                }
-                            </script>
-                            <code>'4Aq8'B{'8A'8G}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Appoggiatura</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
         </section>
-        <section>
-            <h4>Single Rests</h4>
-            <p>
-                Rests for single notes MUST be indicated by a hyphen/minus character <code>-</code>. This character
-                MAY be preceded by a <a href="#duration">duration</a> value giving the musical duration of the rest.
-                If the duration is omitted, the last specified duration is used. If no duration is supplied in the
-                <a>encoding</a> a default duration of <code>4</code> is assumed.
-            </p>
-            <aside class="example" title="Encoding Rests">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "8-"
-                                }
-                            </script>
-                            <code>8-</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Eighth-note rest</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "2-"
-                                }
-                            </script>
-                            <code>2-</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Half-note rest</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-    </section>
-    <section>
-        <h3>Groups</h3>
         <section>
             <h4>Beams</h4>
-            <div class="issue" data-number="24"></div>
             <p>
                 Beamed notes are encoded using braces <code>{}</code>.
             </p>
@@ -1558,6 +1419,7 @@
             </aside>
         </section>
         <section>
+            <div class="issue" data-number="123"></div>
             <h4>Tuplets</h4>
             <p>
                 A tuplet group MUST begin with a duration value to indicate the duration
@@ -1579,8 +1441,15 @@
                 given, a value of <code>3</code> is the default.
             </p>
             <p>
-                A special encoding shortcut is available for <a href="#triplets">Triplets</a>.
+                Since the default number of beats in the tuplet is <code>3</code>, these two
+                encodings of a triplet are considered to be equivalent:
             </p>
+            <aside class="example">
+                <pre class="code">
+                    8(6ABC;3) or 8({6ABC};3)
+                    8(6ABC) or 8({6ABC})
+                </pre>
+            </aside>
             <aside class="example" title="Encoding Special Rhythmic Groupings">
                 <table class="simple" style="width: 100%">
                     <thead>
@@ -1638,63 +1507,6 @@
             </aside>
         </section>
         <section>
-            <h4>Appogiatura Group</h4>
-            <p>
-                For multiple consecutive appogiatura notes, the appogiatura group SHOULD
-                be used. The lower-case characters <code>qq</code> MUST be given as the first
-                characters before the first note of the group, and the lower-case character
-                <code>r</code> MUST be the last character in the final note of the group.
-                There MUST be more than one note in a appogiatura group.
-            </p>
-            <p>
-                The <code>r</code> character MUST follow the closing beam character
-                that is part of the appogiatura group.
-            </p>
-            <p>
-                An appogiatura group with beams MAY occur within a non-appogiatura
-                beam.
-            </p>
-            <aside class="example" title="Encoding Appogiatura Groups">
-                <table class="simple" style="width: 100%">
-                    <thead>
-                    <tr>
-                        <th>Code</th>
-                        <th>Notation</th>
-                        <th>Remarks</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "'4Aqq''{'8B''8C}r{''8D'8B}"
-                                }
-                            </script>
-                            <code>'4Aqq''{'8B''8C}r{''8D'8B}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Appoggiatura group</td>
-                    </tr>
-                    <tr class="notation-example">
-                        <td class="notation-code">
-                            <script type="application/json">
-                                {
-                                    "clef": "G-2",
-                                    "data": "{'8Aqq''{'8B''8C}r''8D}"
-                                }
-                            </script>
-                            <code>{'8Aqq''{'8B''8C}r''8D}</code>
-                        </td>
-                        <td class="notation-result"></td>
-                        <td>Beamed appoggiatura group within an outer beam</td>
-                    </tr>
-                    </tbody>
-                </table>
-            </aside>
-        </section>
-        <section>
             <h4>Chords</h4>
             <div class="issue" data-number="2"></div>
             <div class="issue" data-number="60"></div>
@@ -1729,10 +1541,200 @@
         </section>
     </section>
     <section>
-        <h3>Staff Symbols</h3>
+        <h3>Ornaments</h3>
+        <section>
+            <h4>Trills</h4>
+            <p>
+                The lower-case character <code>t</code> is used to indicate
+                a trilled note. The <code>t</code> MUST immediately follow the
+                note name.
+            </p>
+            <aside class="example">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2Gt'1C"
+                                }
+                            </script>
+                            <code>2Gt</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Fermata</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Fermatas</h4>
+            <p>
+                The lower-case character <code>p</code> is used to indicate
+                a fermata on a note. The <code>p</code> MUST immediately precede the
+                note name, and MUST follow any other attributes on the note that
+                occur before the note name.
+            </p>
+            <aside class="example">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2G1(C)"
+                                }
+                            </script>
+                            <code>2G1''pC</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Fermata</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+        </section>
+        <section>
+            <h4>Grace Notes</h4>
+            <p>
+                There are two types of grace note: Acciaccatura and appogiatura.
+            </p>
+            <p>
+                For a single acciaccatura the lower-case character <code>g</code>
+                MUST be used. This character MUST be specified in the order given above;
+                that is, it MUST precede the note name, and MUST also precede all other
+                optional attributes of the note. Consecutive single acciaccatura
+                SHOULD NOT occur.
+            </p>
+            <p>
+                For a single appogiatura note, the lower-case character <code>q</code>
+                MUST be used. This character MUST be specified in the order given above;
+                that is, it MUST precede the note name, and MUST also precede all other
+                optional attributes of the note.
+            </p>
+            <p>
+                Multple appogiatura notes SHOULD be encoded using an <a href="#appogiatura-groups">
+                Appogiatura Group</a>. Consecutive single appogiatura SHOULD NOT occur.
+            </p>
+            <aside class="example" title="Encoding Grace Notes">
+                <table class="simple" style="width: 100%">
+                    <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'4Ag''C{''8D'8B}"
+                                }
+                            </script>
+                            <code>'4Ag''C{''8D'8B}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Acciaccatura</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "'4Aq8'B{'8A'8G}"
+                                }
+                            </script>
+                            <code>'4Aq8'B{'8A'8G}</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Appoggiatura</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </aside>
+            <section>
+                <h5>Appogiatura Groups</h5>
+                <p>
+                    For multiple consecutive appogiatura notes, the appogiatura group SHOULD
+                    be used. The lower-case characters <code>qq</code> MUST be given as the first
+                    characters before the first note of the group, and the lower-case character
+                    <code>r</code> MUST be the last character in the final note of the group.
+                    There MUST be more than one note in a appogiatura group.
+                </p>
+                <p>
+                    The <code>r</code> character MUST follow the closing beam character
+                    that is part of the appogiatura group.
+                </p>
+                <p>
+                    An appogiatura group with beams MAY occur within a non-appogiatura
+                    beam.
+                </p>
+                <aside class="example" title="Encoding Appogiatura Groups">
+                    <table class="simple" style="width: 100%">
+                        <thead>
+                        <tr>
+                            <th>Code</th>
+                            <th>Notation</th>
+                            <th>Remarks</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr class="notation-example">
+                            <td class="notation-code">
+                                <script type="application/json">
+                                    {
+                                        "clef": "G-2",
+                                        "data": "'4Aqq''{'8B''8C}r{''8D'8B}"
+                                    }
+                                </script>
+                                <code>'4Aqq''{'8B''8C}r{''8D'8B}</code>
+                            </td>
+                            <td class="notation-result"></td>
+                            <td>Appoggiatura group</td>
+                        </tr>
+                        <tr class="notation-example">
+                            <td class="notation-code">
+                                <script type="application/json">
+                                    {
+                                        "clef": "G-2",
+                                        "data": "{'8Aqq''{'8B''8C}r''8D}"
+                                    }
+                                </script>
+                                <code>{'8Aqq''{'8B''8C}r''8D}</code>
+                            </td>
+                            <td class="notation-result"></td>
+                            <td>Beamed appoggiatura group within an outer beam</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </aside>
+            </section>
+        </section>
+    </section>
+    <section>
+        <h3>Measure and Staff Symbols</h3>
         <section>
             <h4>Bar Lines</h4>
-            <div class="issue" data-number="44"></div>
             <p>
                 Bar lines MUST be indicated using one of the code options given in [[[#barlines-spec]]].
             </p>
@@ -1747,78 +1749,78 @@
                     <colgroup class="header"></colgroup>
                     <colgroup span="3"></colgroup>
                     <thead>
-                        <tr>
-                            <th>Code</th>
-                            <th>Notation</th>
-                            <th>Remarks</th>
-                        </tr>
+                    <tr>
+                        <th>Code</th>
+                        <th>Notation</th>
+                        <th>Remarks</th>
+                    </tr>
                     </thead>
                     <tbody>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "/"
-                                    }
-                                </script>
-                                <code>/</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Single bar line</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "//"
-                                    }
-                                </script>
-                                <code>//</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Double bar line</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "//:"
-                                    }
-                                </script>
-                                <code>//:</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Double bar line with repeat sign on the right</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "://"
-                                    }
-                                </script>
-                                <code>://</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Double bar line with repeat sign on the left</td>
-                        </tr>
-                        <tr class="notation-example">
-                            <td class="notation-code">
-                                <script type="application/json">
-                                    {
-                                        "clef": "G-2",
-                                        "data": "://:"
-                                    }
-                                </script>
-                                <code>://:</code>
-                            </td>
-                            <td class="notation-result"></td>
-                            <td>Double bar line with repeat sign on the left and on the right</td>
-                        </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "/"
+                                }
+                            </script>
+                            <code>/</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Single bar line</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "//"
+                                }
+                            </script>
+                            <code>//</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Double bar line</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "//:"
+                                }
+                            </script>
+                            <code>//:</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Double bar line with repeat sign on the right</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "://"
+                                }
+                            </script>
+                            <code>://</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Double bar line with repeat sign on the left</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "://:"
+                                }
+                            </script>
+                            <code>://:</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>Double bar line with repeat sign on the left and on the right</td>
+                    </tr>
                     </tbody>
                 </table>
                 <figcaption>Types of bar lines</figcaption>
@@ -1950,12 +1952,13 @@
             </aside>
         </section>
         <section>
-            <h4>Change of Clef, Key Signature, Time Signature</h4>
+            <h4>Changes to Staff Definitions</h4>
             <p>
                 Clefs, key signatures, and time signatures MAY be changed within an incipit.
             </p>
             <p>
-                The percent character <code>%</code> MUST be used to indicate a clef change. A clef change MAY occur anywhere
+                The percent character <code>%</code> MUST be used to indicate a clef change. A clef change MAY occur
+                anywhere
                 within the music notation section. This character MUST be followed by a clef definition according
                 to the specifications given in the <a href="#clef">Clef</a> section.
             </p>
@@ -2027,9 +2030,9 @@
         </section>
     </section>
     <section>
-        <h4>Shortcuts</h4>
+        <h3>Shortcuts</h3>
         <section>
-            <h5>Repeat group</h5>
+            <h4>Repeat group</h4>
             <p>
                 If one or notes or rests are repeated several times, a repeat group
                 MAY be used.
@@ -2155,24 +2158,6 @@
                 </table>
             </aside>
         </section>
-        <section>
-            <h5>Triplets</h5>
-            <p>
-                The triplet is a special case; strictly speaking, it should be coded as follows:
-            </p>
-            <pre class="text">
-                8(6ABC;3) or 8({6ABC};3)
-            </pre>
-            <p>
-                Instead, the following shortcut is permitted:
-            </p>
-            <pre class="text">
-                (6ABC) or ({6ABC})
-            </pre>
-            <p>
-                The rhythmic value inside the parentheses is required.
-            </p>
-        </section>
     </section>
 </section>
 <section>
@@ -2239,41 +2224,41 @@
                 <colgroup class="header"></colgroup>
                 <colgroup span="2"></colgroup>
                 <thead>
-                    <tr>
-                        <th>Field</th>
-                        <th>MARC21</th>
-                        <th>UNIMARC</th>
-                    </tr>
+                <tr>
+                    <th>Field</th>
+                    <th>MARC21</th>
+                    <th>UNIMARC</th>
+                </tr>
                 </thead>
                 <tbody>
-                    <tr>
-                        <td>Clef</td>
-                        <td><code>$g</code></td>
-                        <td><code>$m</code></td>
-                    </tr>
-                    <tr>
-                        <td>Key Signature</td>
-                        <td><code>$n</code></td>
-                        <td><code>$n</code></td>
-                    </tr>
-                    <tr>
-                        <td>Time Signature</td>
-                        <td><code>$o</code></td>
-                        <td><code>$o</code></td>
-                    </tr>
-                    <tr>
-                        <td>Musical Notation</td>
-                        <td><code>$p</code></td>
-                        <td><code>$p</code></td>
-                    </tr>
-                    <tr>
-                        <td>Source</td>
-                        <td><code>$2</code></td>
-                        <td><code>$2</code></td>
-                    </tr>
+                <tr>
+                    <td>Clef</td>
+                    <td><code>$g</code></td>
+                    <td><code>$m</code></td>
+                </tr>
+                <tr>
+                    <td>Key Signature</td>
+                    <td><code>$n</code></td>
+                    <td><code>$n</code></td>
+                </tr>
+                <tr>
+                    <td>Time Signature</td>
+                    <td><code>$o</code></td>
+                    <td><code>$o</code></td>
+                </tr>
+                <tr>
+                    <td>Musical Notation</td>
+                    <td><code>$p</code></td>
+                    <td><code>$p</code></td>
+                </tr>
+                <tr>
+                    <td>Source</td>
+                    <td><code>$2</code></td>
+                    <td><code>$2</code></td>
+                </tr>
                 </tbody>
             </table>
-        <figcaption>MARC21 and UNIMARC subfields for the Plaine &amp; Easie Code</caption>
+            <figcaption>MARC21 and UNIMARC subfields for the Plaine &amp; Easie Code</caption>
         </figure>
     </section>
     <section>
@@ -2321,8 +2306,8 @@
         <h3>JavaScript Object Notation (JSON)</h3>
         <p>
             Plaine &amp; Easie Code MAY be represented as JavaScript Object Notation
-           ([[JSON]]). All JSON encodings of the Plaine &amp; Easie Code MUST be valid
-           JSON.
+            ([[JSON]]). All JSON encodings of the Plaine &amp; Easie Code MUST be valid
+            JSON.
         </p>
         <p>
             The keys in the JSON MUST be one of the following: <code>clef</code>,


### PR DESCRIPTION
This commit is the first pass at overhauling the structure to make it flow logically. A second commit after this one will adjust the prose to fit the new structure, but this commit is primarily moving things around.

The "Plaine and Easie Code" section was removed, and the two main sections within promoted up: Staff Definitions and Musical Notation.

Within Musical Notation, the sections were moved around. Now, things that are attributes of notes and rests are grouped under the "Notes and Rests" section; Grouping mechanisms like beams or tuplets are in their own section, and staff elements, like bar lines, measure rests, and changes, are in their own section.

There may still be a little bit of re-ordering in the notes and rests section to get a consistent flow.

This effort is in response to the need to figure out some higher-level concepts in the PAEC, such as what a "note" is, and what attributes are part of a "note".
