### PR TITLE
Fixed: Remove key and mode

### DIFF
--- a/v2/changes.html
+++ b/v2/changes.html
@@ -203,6 +203,35 @@
             <section>
                 <h3>Order of elements within a note</h3>
             </section>
+            <section>
+                <h3>Key and Mode</h3>
+                <p>
+                    The ability to explicitly state key and / or mode in Plaine &amp; Easie was not included
+                    in Version 2.
+                </p>
+                <p>
+                    The status of this ability was unclear. MARC21 (<code>$r</code>) and UNIMARC permit the encoding
+                    of key and mode, and indeed the MARC21 documentation states that the format of this field comes
+                    from the Plaine &amp; Easie Code. However, the latest updates to Version 1 of the Code did not
+                    actually specify this format.
+                </p>
+                <p>
+                    The ability to encode the key or mode of a piece was available in the initial versions of the
+                    Plaine &amp; Easie Code, but the format of this field was not strictly defined.
+                </p>
+                <p>
+                    It was decided to not formalize this field in Version 2 of the Code. The judgement of a major
+                    or a minor key is not strictly necessary for capturing the notation of an incipit, and instead is
+                    something that should be captured in an explanatory note or a dedicated cataloguing field. The
+                    application of this field, particularly in the capture of non-CWMN music, would also require
+                    expanding the format and validation of the values beyond a simple rubric.
+                </p>
+                <p>
+                    The effect of this change may be that the subfield remains available in MARC21 and UNIMARC, but the
+                    format is no longer defined in reference to the Plaine &amp; Easie Code.
+                </p>
+            </section>
+
         </section>
     </body>
 </html>


### PR DESCRIPTION
The status of the "Key / Mode" field is ambiguous. It wasn't actually defined in Version 1, although the MARC21 documentation would seem to indicate otherwise.

Given the wide range of possible tonalities, particularly if we expand this to older music, Greek church modes, Indian music, etc. we can simply not carry this forward. To that end, a clarification in the Changes documentation is made.

Fixes #102