### PR TITLE
Fixed: ligatures in CWMN

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -1463,8 +1463,7 @@
             </p>
             <p>
                 A ligature MUST NOT occur between a note and a rest, and MUST NOT occur between a note and a group
-                of notes. (i.e., a beam, tuplet, or chord.) Ligatures also MUST NOT occur within a beam, tuplet,
-                or chord.
+                of notes. (e.g., between a note and a tuplet.) Ligatures also MUST NOT occur within a tuplet.
             </p>
             <p>
                 When a ligature character is used, it MUST be the final modifier, occurring after the pitch name and

--- a/v2/index.html
+++ b/v2/index.html
@@ -1453,7 +1453,8 @@
             <h4>Ligatures</h4>
             <p>
                 Two notes joined in a ligature can be indicated with the lower-case character
-                <code>u</code>.
+                <code>u</code>. Ligatures are only used when encoding <a data-lt="Mensural Notation">Mensural</a> and <a data-lt="Neume Notation">Neume</a>
+                notation and MUST NOT be used when encoding <a data-lt="Common Western Music Notation">CWMN</a>.
             </p>
             <p>
                 Several consecutive notes MAY be joined in a single ligature by adding the <code>u</code>
@@ -1504,7 +1505,7 @@
                         <td class="notation-code">
                             <script type="application/json">
                                 {
-                                    "clef": "G-2",
+                                    "clef": "G+2",
                                     "data": "4Cu8Du,A"
                                 }
                             </script>


### PR DESCRIPTION
Clarifies that ligatures are not valid in CWMN encodings.

Fixes #166