### PR TITLE
Fixed: clarify that durations also apply to rests

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -850,7 +850,7 @@
         <section id="durations">
             <h4>Durations</h4>
             <p>
-                Note and rest durations are given as integer values in the range <code>0-9</code>. The corresponding
+                Note, chord, and rest durations are given as integer values in the range <code>0-9</code>. The corresponding
                 duration for each number is given in [[[#note-duration-map]]].
             </p>
             <figure id="note-duration-map">

--- a/v2/index.html
+++ b/v2/index.html
@@ -1078,7 +1078,7 @@
                                     "data": "4....-"
                                 }
                             </script>
-                            <code>4.-</code>
+                            <code>4....-</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>quad-dotted quarter rest</td>

--- a/v2/index.html
+++ b/v2/index.html
@@ -850,8 +850,8 @@
         <section id="durations">
             <h4>Durations</h4>
             <p>
-                Note durations are given as integer values in the range <code>0-9</code>. The corresponding
-                note duration for each number is given in [[[#note-duration-map]]].
+                Note and rest durations are given as integer values in the range <code>0-9</code>. The corresponding
+                duration for each number is given in [[[#note-duration-map]]].
             </p>
             <figure id="note-duration-map">
                 <table class="data" style="width: 100%">
@@ -1006,28 +1006,30 @@
                     </tr>
                     </tbody>
                 </table>
-                <figcaption>Note duration value mapping, ordered from longest to shortest note value.</figcaption>
+                <figcaption>
+                    Note and rest duration value mapping, ordered from longest to shortest value.
+                </figcaption>
             </figure>
             <p>
-                The duration value for a given note MAY be omitted. If the duration is omitted, the last specified
-                duration is used for all following notes.
+                The duration value for a given note or rest MAY be omitted. If the duration is omitted, the last
+                specified duration is used for all following notes or rests.
             </p>
             <p>
-                An <a>encoding</a> MAY omit all duration indications. If no duration is supplied on any note, all
-                notes have an implied duration value of <code>4</code> (quarter note / crochet / semiminim).
+                An <a>encoding</a> MAY omit all duration indications. If no duration is supplied on any note or rest,
+                all notes or rests have an implied duration value of <code>4</code> (quarter / crochet / semiminim).
             </p>
             <p>
                 Duration values MUST be interpreted differently if the encoding is in
-                <a data-lt="Common Western Music Notation"><abbr title="Common Western Music Notation">CWMN</abbr></a> or
-                <a data-lt="Mensural Music Notation">Mensural notation</a>. Mensural notation
-                MUST NOT use durations of <code>3</code>, <code>5</code>, or <code>7</code>.
+                <a data-lt="Common Western Music Notation"><abbr title="Common Western Music Notation">CWMN</abbr></a>
+                or <a data-lt="Mensural Music Notation">Mensural notation</a>. Mensural notation MUST NOT use
+                durations of <code>3</code>, <code>5</code>, or <code>7</code>.
             </p>
             <p>
-                Notes in neume notation MUST NOT be given a duration value, and there is no implied duration.
+                Notes and rests in neume notation MUST NOT be given a duration value, and there is no implied duration.
             </p>
             <p>
                 For <abbr>CWMN</abbr> the period character <code>.</code> MAY be used to indicate a dot of augmentation,
-                extending the duration of the note by half the indicated duration value. This character MUST be
+                extending the duration of the note or rest by half the indicated duration value. This character MUST be
                 directly appended to the duration value. Multiple dots MAY be used, with each successive dot indicating
                 that the duration is extended by half the value of the previous dot. The number of dots MUST NOT exceed
                 four.
@@ -1067,6 +1069,19 @@
                         </td>
                         <td class="notation-result"></td>
                         <td>Double-dotted eighth note and its equivalent in tied notes</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "4....-"
+                                }
+                            </script>
+                            <code>4.-</code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>quad-dotted quarter rest</td>
                     </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
The duration section was very note-centric, so it felt necessary to clarify that the durations also apply to rests.