### PR TITLE
Fixed: Rework and clarify chords

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -1408,11 +1408,20 @@
                 end note is considered to have the same duration as the initial note.
             </p>
             <p>
-                An underscore MAY be preceded by the opening characters of a <a href="#beams">beam</a> or <a href="#tuplets">tuplet</a>.
+                An underscore MAY be preceded by the opening characters of a <a href="#beams">beam</a> or
+                <a href="#tuplets">tuplet</a>.
             </p>
             <p>
                 Tied notes MAY occur over bar lines. The underscore MUST occur after the bar line, but MAY be preceded
-                in the new measure by a <a href="#durations">duration</a> or the opening characters of a <a href="#beams">beam</a> or <a href="#tuplets">tuplet</a>.
+                in the new measure by a <a href="#durations">duration</a> or the opening characters of a
+                <a href="#beams">beam</a> or <a href="#tuplets">tuplet</a>.
+            </p>
+            <p>
+                <a href="#chords">Chords</a> MAY be tied. For tied chords, the underscore <code>_</code>
+                represents both the tie and the final chord. The final chord has the same pitches as the preceding
+                chord. An underscore MAY be preceded by a duration value, which indicates a different duration
+                for the final chord. If no duration value is supplied, the final chord has the same
+                duration as the preceding chord.
             </p>
             <aside class="example" title="Encoding Ties">
                 <table class="simple" style="width: 100%">
@@ -1722,10 +1731,10 @@
                 notes in a chord are assigned the same duration value.
             </p>
             <p>
-               A <a href="#durations">duration</a> value MAY precede the <code>^</code>. Two or more <a href="#note-names">note names</a>
-                (with optional octave and accidental indications) MUST immediately follow the <code>^</code>.
-               Notes within the chord SHOULD be ordered from the lowest to the highest on the staff line.
-               Duration values for the individual notes within a chord MUST NOT be supplied.
+               A <a href="#durations">duration</a> value MAY precede the <code>^</code>. Two or more
+               <a href="#note-names">note names</a> (with optional octave and accidental indications) MUST
+               immediately follow the <code>^</code>. Notes within the chord SHOULD be ordered from the lowest to the
+               highest on the staff line. Duration values for the individual notes within a chord MUST NOT be supplied.
             </p>
             <p>
                 If the chord duration is omitted, the last specified duration is used. If no duration is
@@ -1735,10 +1744,8 @@
                 A <code>p</code> character MAY follow the duration to indicate the chord has a fermata.
             </p>
             <p>
-                An underscore, <code>_</code>, is used to indicate a tied chord. Like with <a href="#ties">notes</a>,
-                the underscore represents both the tie and the final chord. An underscore MAY be preceded
-                by a <a href="#durations">duration</a> value, which serves to indicate a different duration
-                of the end note from the initial note.
+                Chords MAY be tied using the underscore character <code>_</code>. See the
+                <a href="#ties">Ties</a> section for tied chord syntax and interpretation.
             </p>
             <p>
                 Mensural and neume notation <a data-lt="Encoding">encodings</a> MUST NOT contain chords.

--- a/v2/index.html
+++ b/v2/index.html
@@ -1741,7 +1741,11 @@
                 supplied in the <a>encoding</a>, a default duration of <code>4</code> is assumed.
             </p>
             <p>
-                A <code>p</code> character MAY follow the duration to indicate the chord has a fermata.
+                A chord MAY include the note modifiers <code>t</code> and <code>p</code> to indicate
+                that the chord has a trill or fermata. These modifiers MUST follow the chord duration
+                and MUST precede the opening chord character <code>^</code>. When both modifiers are
+                present, <code>t</code> MUST precede <code>p</code>, following the same modifier order for
+                notes.
             </p>
             <p>
                 Chords MAY be tied using the underscore character <code>_</code>. See the
@@ -1785,6 +1789,32 @@
                         </td>
                         <td class="notation-result"></td>
                         <td>A chord with a fermata</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2t^AxF>"
+                                }
+                            </script>
+                            <code>2t^AxF></code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>A chord with a trill</td>
+                    </tr>
+                    <tr class="notation-example">
+                        <td class="notation-code">
+                            <script type="application/json">
+                                {
+                                    "clef": "G-2",
+                                    "data": "2tp^AxF>"
+                                }
+                            </script>
+                            <code>2tp^AxF></code>
+                        </td>
+                        <td class="notation-result"></td>
+                        <td>A chord with a trill and a fermata</td>
                     </tr>
                     <tr class="notation-example">
                         <td class="notation-code">

--- a/v2/index.html
+++ b/v2/index.html
@@ -1735,6 +1735,8 @@
                <a href="#note-names">note names</a> (with optional octave and accidental indications) MUST
                immediately follow the <code>^</code>. Notes within the chord SHOULD be ordered from the lowest to the
                highest on the staff line. Duration values for the individual notes within a chord MUST NOT be supplied.
+               Note modifiers, such as trills or fermatas, MUST NOT be specified for individual notes within a
+               chord.
             </p>
             <p>
                 If the chord duration is omitted, the last specified duration is used. If no duration is
@@ -1745,8 +1747,7 @@
                 to indicate that the chord as a whole has a trill or fermata. These modifiers MUST
                 immediately follow the closing chord character <code>></code>. When both modifiers
                 are present, <code>t</code> MUST precede <code>p</code>, following the same modifier
-                order used for notes. A chord modifier applies to the whole chord, not to an individual
-                note within the chord.
+                order used for notes.
             </p>
             <p>
                 Chords MAY be tied using the underscore character <code>_</code>. See the

--- a/v2/index.html
+++ b/v2/index.html
@@ -1741,11 +1741,12 @@
                 supplied in the <a>encoding</a>, a default duration of <code>4</code> is assumed.
             </p>
             <p>
-                A chord MAY include the note modifiers <code>t</code> and <code>p</code> to indicate
-                that the chord has a trill or fermata. These modifiers MUST follow the chord duration
-                and MUST precede the opening chord character <code>^</code>. When both modifiers are
-                present, <code>t</code> MUST precede <code>p</code>, following the same modifier order for
-                notes.
+                A chord MAY be followed by the modifier characters <code>t</code> and <code>p</code>
+                to indicate that the chord as a whole has a trill or fermata. These modifiers MUST
+                immediately follow the closing chord character <code>></code>. When both modifiers
+                are present, <code>t</code> MUST precede <code>p</code>, following the same modifier
+                order used for notes. A chord modifier applies to the whole chord, not to an individual
+                note within the chord.
             </p>
             <p>
                 Chords MAY be tied using the underscore character <code>_</code>. See the
@@ -1782,10 +1783,10 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2p^AxF>"
+                                    "data": "2^AxF>p"
                                 }
                             </script>
-                            <code>2p^AxF></code>
+                            <code>2^AxF>p</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>A chord with a fermata</td>
@@ -1795,10 +1796,10 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2t^AxF>"
+                                    "data": "2^AxF>t"
                                 }
                             </script>
-                            <code>2t^AxF></code>
+                            <code>2^AxF>t</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>A chord with a trill</td>
@@ -1808,10 +1809,10 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2tp^AxF>"
+                                    "data": "2^AxF>tp"
                                 }
                             </script>
-                            <code>2tp^AxF></code>
+                            <code>2^AxF>tp</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>A chord with a trill and a fermata</td>


### PR DESCRIPTION
- Moves ties on chords to the "ties" section, since it avoids needing to re-define how ties interact with beams and tuplets (they follow the same rules). 
- Added a cross-reference to ties from chords
- Adds trills to chords (#148)
- Clarifies how trills interact with fermatas
- Adds a couple more examples of fermatas and trills on chords