### PR TITLE
Second Pass at Representation Formats

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -2493,9 +2493,7 @@
 <section id="representation-formats">
     <h2>Representation Formats</h2>
     <p>
-        This section provides the specification of the acceptable representations of the Plaine and
-        Easie Code. It is expected that these representations—with the possible exception of
-        "single-line text"—are constructed and used by automated tools and not written "by hand."
+        This section specifies structured representations for the Plaine and Easie Code.
     </p>
     <section id="character-encodings">
         <h3>Character Encodings</h3>
@@ -2586,7 +2584,7 @@
             <figcaption>MARC21 and UNIMARC subfields for the Plaine and Easie Code</figcaption>
         </figure>
     </section>
-    <section>
+    <section id="multi-line-text-representation">
         <h3>Multi-Line Text with Field Delimiters</h3>
         <p>
             The Plaine and Easie Code can be represented in a multi-line text format.
@@ -2601,10 +2599,9 @@
         </p>
         <p>
             The field identifiers defined by this specification are: <code>@clef</code>,
-            <code>@keysig</code>, <code>@timesig</code>, <code>@key</code>,
-            <code>@data</code>, <code>@end</code>, and <code>@version</code>. The multi-line text representation
-            MAY contain field identifiers other than those listed above, but they MUST be ignored for the purposes
-            of interpreting the Plaine and Easie Code.
+            <code>@keysig</code>, <code>@timesig</code>, <code>@data</code>, <code>@end</code>,
+            and <code>@version</code>. The multi-line text representation MAY contain field identifiers other than
+            those listed above, but they MUST be ignored for the purposes of interpreting the Plaine and Easie Code.
         </p>
         <p>
             The field value MUST immediately follow the colon in the field identifier. The field value MUST NOT
@@ -2612,15 +2609,15 @@
             enclosed in quotation marks.
         </p>
         <p>
-            There MUST be at least two fields in the encoding: <code>clef</code> and <code>data</code>. All other fields
-            MAY be present.
+            Two fields MUST be present in the encoding: <code>@clef</code> and <code>@data</code>. All other
+            fields MAY be present.
         </p>
         <p>
             The <code>@end</code> field MAY be provided. If provided, it MUST be the final field in the list of fields.
             Any fields following an <code>@end</code> field MUST be considered part of another encoding. A
             value for the <code>@end</code> field MAY be provided. If no value is provided, the <code>@end</code> field
             MUST NOT end with a colon. The value of the <code>@end</code> field MUST NOT contain a newline character,
-            but MAY contain any other alpha-numeric ASCII string.
+            but MAY contain any ASCII Graphic Character, as defined in [[RFC20]].
         </p>
         <p>
             The value of the <code>@version</code> identifier MUST be <code>pe2</code> for incipits that conform
@@ -2642,29 +2639,36 @@
     <section>
         <h3>JavaScript Object Notation (JSON)</h3>
         <p>
-            Plaine and Easie Code can be represented as JavaScript Object Notation
-            ([[JSON]]). All JSON encodings of the Plaine and Easie Code MUST be valid
-            JSON.
+            Plaine and Easie Code can be represented as JavaScript Object Notation ([[JSON]]). All JSON encodings of
+            the Plaine and Easie Code MUST be valid JSON.
         </p>
         <p>
-            The keys in the JSON defined by this specification are: <code>clef</code>,
-            <code>keysig</code>, <code>timesig</code>, <code>key</code>,
-            <code>data</code>, <code>label</code>, and <code>version</code>. Unlike the multi-line text representation,
-            JSON keys MUST NOT begin with an at sign character <code>@</code>. The JSON representation MAY contain keys
-            other than those listed above, but they MUST be ignored for the purposes of interpreting the
-            Plaine and Easie Code.
+            The keys in the JSON defined by this specification are: <code>clef</code>, <code>keysig</code>,
+            <code>timesig</code>, <code>data</code>, <code>label</code>, and <code>version</code>.
+            Unlike the multi-line text representation, JSON keys MUST NOT begin with an at sign character
+            <code>@</code>. The JSON representation MAY contain keys other than those listed above, but they MUST be
+            ignored for the purposes of interpreting the Plaine and Easie Code.
         </p>
         <p>
-            There MUST be at least two keys in the encoding: <code>clef</code> and <code>data</code>.
+            Two keys MUST be present in the encoding: <code>clef</code> and <code>data</code>.
         </p>
         <p>
             The <code>label</code> key MAY be provided. The value of the <code>label</code> key MUST NOT contain a
-            newline character, but MAY contain any other alpha-numeric ASCII string.
+            newline character, but MAY contain any ASCII Graphic Character, as defined in [[RFC20]].
         </p>
+        <aside class="note">
+            <p>
+                In the JSON representation there is no need to use an <code>@end</code> field, like there is to
+                separate multiple incipits that use the <a href="#multi-line-text-representation">multi-line
+                text representation</a>. However, since the <code>@end</code> field can also carry a label for
+                the incipit, the <code>label</code> key in the JSON representation provides the equivalent place
+                for this information.
+            </p>
+        </aside>
         <p>
             The value of the <code>version</code> key MUST be <code>pe2</code> for incipits that conform
             to Version 2 of the specification. If a <code>version</code> key is not specified, or if any other
-            value other than <code>pe2</code> is found in the <code>version</code> field, the incipit
+            value other than <code>pe2</code> is found in the <code>version</code> key, the incipit
             MUST be interpreted as conforming to Version 1 of the specification.
         </p>
         <aside class="example" title="JavaScript Object Notation (JSON)">
@@ -2674,7 +2678,7 @@
                     "timesig": "3/2",
                     "keysig": "bB",
                     "data": "=3/2--''A/2.F4G2A/AGG/1A/",
-                    "version": "pe2"
+                    "version": "pe2",
                     "label": "A label for this incipit"
                 }
             </pre>
@@ -2695,20 +2699,24 @@
             that is, the clef declaration starts with the percent character <code>%</code>.
         </p>
         <p>
-            The line of text for specifying a key signature and a time signature follows the same
-            format for an inline change of key and time signatures. See the
-            <a href="#changes-to-staff-definitions">Changes to Staff Definitions</a>
+            Key signature and time signature declarations follow the same syntax as inline changes of key and time
+            signature. See the <a href="#changes-to-staff-definitions">Changes to Staff Definitions</a>
             section for details.
         </p>
         <p>
-            The clef, key signature and time signature MUST be separated from the rest of the music
-            notation by a single space character. The clef, key signature, and time signature declarations
-            MUST NOT themselves be separated by a space character.
+            The clef declaration, and any key signature or time signature declarations, MUST be separated
+            from the music notation by a single space character. The clef, key signature, and time signature
+            declarations MUST NOT themselves be separated by a space character.
         </p>
         <p>
             The rest of the line of text follows the format for the music notation.
             Further changes to the clef, key signature, and time signature are permitted as normal.
         </p>
+        <aside class="note">
+            <p>
+                There is no provision for a label in the single-line text representation.
+            </p>
+        </aside>
         <aside class="example" title="Single-line Plaine and Easie Code">
             <pre>
                 ;pe2%G-2@3/2$bB =3/2--''A/2.F4G2A/AGG/1A/

--- a/v2/index.html
+++ b/v2/index.html
@@ -2597,14 +2597,14 @@
         <p>
             Each field MUST begin with a field identifier. This identifier consists of an at sign
             character <code>@</code>, followed by a field name. The field identifier MUST end with
-            a colon character <code>:</code>.
+            a colon character <code>:</code> (except for the <code>@end</code> field as detailed below.)
         </p>
         <p>
             The field identifiers defined by this specification are: <code>@clef</code>,
             <code>@keysig</code>, <code>@timesig</code>, <code>@key</code>,
-            <code>@data</code>, and <code>@version</code>. The multi-line text representation MAY contain field
-            identifiers other than those listed above, but they MUST be ignored for the purposes of interpreting
-            the Plaine and Easie Code.
+            <code>@data</code>, <code>@end</code>, and <code>@version</code>. The multi-line text representation
+            MAY contain field identifiers other than those listed above, but they MUST be ignored for the purposes
+            of interpreting the Plaine and Easie Code.
         </p>
         <p>
             The field value MUST immediately follow the colon in the field identifier. The field value MUST NOT
@@ -2612,13 +2612,21 @@
             enclosed in quotation marks.
         </p>
         <p>
-            There MUST be at least two fields in the encoding: <code>clef</code> and <code>data</code>.
+            There MUST be at least two fields in the encoding: <code>clef</code> and <code>data</code>. All other fields
+            MAY be present.
+        </p>
+        <p>
+            The <code>@end</code> field MAY be provided. If provided, it MUST be the final field in the list of fields.
+            Any fields following an <code>@end</code> field MUST be considered part of another encoding. A
+            value for the <code>@end</code> field MAY be provided. If no value is provided, the <code>@end</code> field
+            MUST NOT end with a colon. The value of the <code>@end</code> field MUST NOT contain a newline character,
+            but MAY contain any other alpha-numeric ASCII string.
         </p>
         <p>
             The value of the <code>@version</code> identifier MUST be <code>pe2</code> for incipits that conform
             to Version 2 of the specification. If a <code>@version</code> identifier is not specified, or if any other
             value other than <code>pe2</code> is found in the <code>@version</code> field, the incipit
-            MUST be interpreted as conforming to Version 1 of the specification.
+            MUST be interpreted as conforming to Version 1 of the Plaine and Easie Code.
         </p>
         <aside class="example" title="Multi-line text with field delimiters">
             <pre>
@@ -2627,6 +2635,7 @@
                 @keysig:bB
                 @data:=3/2--''A/2.F4G2A/AGG/1A/
                 @version:pe2
+                @end:A label for this incipit
             </pre>
         </aside>
     </section>
@@ -2640,13 +2649,17 @@
         <p>
             The keys in the JSON defined by this specification are: <code>clef</code>,
             <code>keysig</code>, <code>timesig</code>, <code>key</code>,
-            <code>data</code>, and <code>version</code>. Unlike the multi-line text representation, they MUST NOT
-            begin with an at sign character <code>@</code>. The JSON representation MAY contain keys
+            <code>data</code>, <code>label</code>, and <code>version</code>. Unlike the multi-line text representation,
+            JSON keys MUST NOT begin with an at sign character <code>@</code>. The JSON representation MAY contain keys
             other than those listed above, but they MUST be ignored for the purposes of interpreting the
             Plaine and Easie Code.
         </p>
         <p>
             There MUST be at least two keys in the encoding: <code>clef</code> and <code>data</code>.
+        </p>
+        <p>
+            The <code>label</code> key MAY be provided. The value of the <code>label</code> key MUST NOT contain a
+            newline character, but MAY contain any other alpha-numeric ASCII string.
         </p>
         <p>
             The value of the <code>version</code> key MUST be <code>pe2</code> for incipits that conform
@@ -2662,6 +2675,7 @@
                     "keysig": "bB",
                     "data": "=3/2--''A/2.F4G2A/AGG/1A/",
                     "version": "pe2"
+                    "label": "A label for this incipit"
                 }
             </pre>
         </aside>

--- a/v2/index.html
+++ b/v2/index.html
@@ -369,7 +369,8 @@
                         <script type="application/json">
                             {
                                 "clef": "G-2",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>G-2</code>
@@ -382,7 +383,8 @@
                         <script type="application/json">
                             {
                                 "clef": "C*2",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>C*2</code>
@@ -395,7 +397,8 @@
                         <script type="application/json">
                             {
                                 "clef": "F-4",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>F-4</code>
@@ -408,7 +411,8 @@
                         <script type="application/json">
                             {
                                 "clef": "g-2",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>g-2</code>
@@ -421,7 +425,8 @@
                         <script type="application/json">
                             {
                                 "clef": "C:3",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>C:3</code>
@@ -434,7 +439,8 @@
                         <script type="application/json">
                             {
                                 "clef": "[G-2]",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>[G-2]</code>
@@ -491,7 +497,8 @@
                             {
                                 "clef": "C-1",
                                 "keysig": "xFC",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>xFC</code>
@@ -505,7 +512,8 @@
                             {
                                 "clef": "G-2",
                                 "keysig": "bBEA",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>bBEA</code>
@@ -519,7 +527,8 @@
                             {
                                 "clef": "G-2",
                                 "keysig": "bB[EA]",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>bB[EA]</code>
@@ -533,7 +542,8 @@
                             {
                                 "clef": "G-2",
                                 "keysig": "n",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>n</code>
@@ -547,7 +557,8 @@
                             {
                                 "clef": "G-2",
                                 "keysig": "xF[C]G[D]",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>xF[C]G[D]</code>
@@ -610,7 +621,8 @@
                             {
                                 "clef": "G-2",
                                 "timesig": "2/4",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>2/4</code>
@@ -625,7 +637,8 @@
                             {
                                 "clef": "G-2",
                                 "timesig": "12/16",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>12/16</code>
@@ -640,7 +653,8 @@
                             {
                                 "clef": "G-2",
                                 "timesig": "c",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>c</code>
@@ -655,7 +669,8 @@
                             {
                                 "clef": "G-2",
                                 "timesig": "c/",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>c/</code>
@@ -670,7 +685,8 @@
                             {
                                 "clef": "C*3",
                                 "timesig": "o",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>o</code>
@@ -685,7 +701,8 @@
                             {
                                 "clef": "C*3",
                                 "timesig": "o.",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>o.</code>
@@ -700,7 +717,8 @@
                             {
                                 "clef": "C*3",
                                 "timesig": "c3",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>c3</code>
@@ -715,7 +733,8 @@
                             {
                                 "clef": "C*3",
                                 "timesig": "c2",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>c2</code>
@@ -730,7 +749,8 @@
                             {
                                 "clef": "G*2",
                                 "timesig": "c/",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>c/</code>
@@ -745,7 +765,8 @@
                             {
                                 "clef": "G-2",
                                 "timesig": "3/4|4/4",
-                                "data": ""
+                                "data": "",
+                                "version": "pe2"
                             }
                         </script>
                         <code>3/4|4/4</code>
@@ -885,7 +906,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "0G"
+                                    "data": "0G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>0</code>
@@ -898,7 +920,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "9G"
+                                    "data": "9G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>9</code>
@@ -911,7 +934,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "1G"
+                                    "data": "1G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>1</code>
@@ -925,7 +949,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2G"
+                                    "data": "2G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2</code>
@@ -939,7 +964,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "4G"
+                                    "data": "4G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4</code>
@@ -953,7 +979,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "8G"
+                                    "data": "8G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>8</code>
@@ -967,7 +994,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "6G"
+                                    "data": "6G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>6</code>
@@ -981,7 +1009,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "3G"
+                                    "data": "3G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>3</code>
@@ -995,7 +1024,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "5G"
+                                    "data": "5G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>5</code>
@@ -1009,7 +1039,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "7G"
+                                    "data": "7G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>7</code>
@@ -1063,7 +1094,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "4.A"
+                                    "data": "4.A",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4.A</code>
@@ -1076,7 +1108,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "8..A//8A_6A_3A"
+                                    "data": "8..A//8A_6A_3A",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>8..A//8A_6A_3A</code>
@@ -1089,7 +1122,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "4....-"
+                                    "data": "4....-",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4....-</code>
@@ -1129,7 +1163,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "CDEFGAB"
+                                    "data": "CDEFGAB",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>CDEFGAB</code>
@@ -1180,7 +1215,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "'C''B"
+                                    "data": "'C''B",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>'C''B</code>
@@ -1193,7 +1229,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "F-4",
-                                    "data": ",,C,B"
+                                    "data": ",,C,B",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>,,C,B</code>
@@ -1206,7 +1243,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "''C'GC,GC,,G"
+                                    "data": "''C'GC,GC,,G",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>''C'GC,GC,,G</code>
@@ -1219,7 +1257,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "AB''CDC'BA"
+                                    "data": "AB''CDC'BA",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>AB''CDC'BA</code>
@@ -1232,7 +1271,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "ABCD"
+                                    "data": "ABCD",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>ABCD</code>
@@ -1266,7 +1306,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "xG"
+                                    "data": "xG",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>x</code>
@@ -1279,7 +1320,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "bB"
+                                    "data": "bB",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>b</code>
@@ -1292,7 +1334,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "xxG"
+                                    "data": "xxG",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>xx</code>
@@ -1305,7 +1348,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "bbB"
+                                    "data": "bbB",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>bb</code>
@@ -1318,7 +1362,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "nB"
+                                    "data": "nB",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>n</code>
@@ -1382,7 +1427,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "8-"
+                                    "data": "8-",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>8-</code>
@@ -1395,7 +1441,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2-"
+                                    "data": "2-",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2-</code>
@@ -1408,7 +1455,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "4.-"
+                                    "data": "4.-",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4.-</code>
@@ -1467,7 +1515,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "FG_A"
+                                    "data": "FG_A",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>FG_A</code>
@@ -1480,7 +1529,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2''G/_"
+                                    "data": "2''G/_",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2''G/_</code>
@@ -1494,7 +1544,8 @@
                                 {
                                     "clef": "G-2",
                                     "tsig": "2/2",
-                                    "data": "2''G/_/4_"
+                                    "data": "2''G/_/4_",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2''G/_/4_</code>
@@ -1508,7 +1559,8 @@
                                 {
                                     "clef": "G-2",
                                     "tsig": "2/2",
-                                    "data": "2''G/8{_AB}/4_"
+                                    "data": "2''G/8{_AB}/4_",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2''G/8{_AB}/4_</code>
@@ -1563,7 +1615,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G:2",
-                                    "data": "CDuEF"
+                                    "data": "CDuEF",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>CDuEF</code>
@@ -1576,7 +1629,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G+2",
-                                    "data": "4Cu8Du,A"
+                                    "data": "4Cu8Du,A",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4Cu8Du,A</code>
@@ -1629,7 +1683,8 @@
                                     "clef": "G-2",
                                     "keysig": "bBEA",
                                     "timesig": "4/4",
-                                    "data": "{''6E'B8G}{GA}-''C{'3B8..G}"
+                                    "data": "{''6E'B8G}{GA}-''C{'3B8..G}",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>{''6E'B8G}{GA}-''C{'3B8..G}</code>
@@ -1642,7 +1697,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "8{ABy{''CD}r'AB}"
+                                    "data": "8{ABy{''CD}r'AB}",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>8{ABy{''CD}r'AB}</code>
@@ -1713,7 +1769,8 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "c",
-                                    "data": "4(6'DEFGA;5)"
+                                    "data": "4(6'DEFGA;5)",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4(6'DEFGA;5)</code>
@@ -1727,7 +1784,8 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "c",
-                                    "data": "8({'3DEFGA};5)"
+                                    "data": "8({'3DEFGA};5)",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>8({'3DEFGA};5)</code>
@@ -1741,7 +1799,8 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "c",
-                                    "data": "4('4D8E)4('4D8E)"
+                                    "data": "4('4D8E)4('4D8E)",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>4('4D8E)4('4D8E)</code>
@@ -1800,7 +1859,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2^'AxF>/2^AxF>/"
+                                    "data": "2^'AxF>/2^AxF>/",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2^'AxF>/2^AxF>/</code>
@@ -1813,7 +1873,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2^AxF>p"
+                                    "data": "2^AxF>p",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2^AxF>p</code>
@@ -1826,7 +1887,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2^AxF>t"
+                                    "data": "2^AxF>t",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2^AxF>t</code>
@@ -1839,7 +1901,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2^AxF>tp"
+                                    "data": "2^AxF>tp",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2^AxF>tp</code>
@@ -1852,7 +1915,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2^''D'AxF>/2_/4_//"
+                                    "data": "2^''D'AxF>/2_/4_//",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2^''D'AxF>/2_/4_//</code>
@@ -1865,7 +1929,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2^CEG>8(6{_^DxFA>^EGB>})"
+                                    "data": "2^CEG>8(6{_^DxFA>^EGB>})",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2^CEG>8(6{_^DxFA>^EGB>})</code>
@@ -1902,7 +1967,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2Gt"
+                                    "data": "2Gt",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2Gt</code>
@@ -1937,7 +2003,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "2G1''Cp"
+                                    "data": "2G1''Cp",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>2G1''Cp</code>
@@ -1988,7 +2055,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "'4Ag''C{''8D'8B}"
+                                    "data": "'4Ag''C{''8D'8B}",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>'4Ag''C{''8D'8B}</code>
@@ -2001,7 +2069,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "'4Aq8'B{'8A'8G}"
+                                    "data": "'4Aq8'B{'8A'8G}",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>'4Aq8'B{'8A'8G}</code>
@@ -2051,7 +2120,8 @@
                                 <script type="application/json">
                                     {
                                         "clef": "G-2",
-                                        "data": "'4Ay''{'8B''8C}r{''8D'8B}"
+                                        "data": "'4Ay''{'8B''8C}r{''8D'8B}",
+                                        "version": "pe2"
                                     }
                                 </script>
                                 <code>'4Ay''{'8B''8C}r{''8D'8B}</code>
@@ -2064,7 +2134,8 @@
                                 <script type="application/json">
                                     {
                                         "clef": "G-2",
-                                        "data": "{'8Ay''{'8B''8C}r''8D}"
+                                        "data": "{'8Ay''{'8B''8C}r''8D}",
+                                        "version": "pe2"
                                     }
                                 </script>
                                 <code>{'8Ay''{'8B''8C}r''8D}</code>
@@ -2109,7 +2180,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "/"
+                                    "data": "/",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>/</code>
@@ -2122,7 +2194,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "//"
+                                    "data": "//",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>//</code>
@@ -2135,7 +2208,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "//:"
+                                    "data": "//:",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>//:</code>
@@ -2148,7 +2222,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "://"
+                                    "data": "://",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>://</code>
@@ -2161,7 +2236,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "://:"
+                                    "data": "://:",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>://:</code>
@@ -2188,7 +2264,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "CDE/FGA"
+                                    "data": "CDE/FGA",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>CDE/FGA</code>
@@ -2201,7 +2278,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "CDE/FGA//"
+                                    "data": "CDE/FGA//",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>CDE/FGA//</code>
@@ -2214,7 +2292,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "CDE//:FGA://"
+                                    "data": "CDE//:FGA://",
+                                    "version": "pe2"
                                 }
                             </script>
 
@@ -2228,7 +2307,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "//:CDE://:FGA://"
+                                    "data": "//:CDE://:FGA://",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>//:CDE://:FGA://</code>
@@ -2272,7 +2352,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "=/"
+                                    "data": "=/",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>=/</code>
@@ -2285,7 +2366,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "=35/"
+                                    "data": "=35/",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>=35/</code>
@@ -2298,7 +2380,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "=5//=10/=/"
+                                    "data": "=5//=10/=/",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>=5//=10/=/</code>
@@ -2356,7 +2439,8 @@
                             <script type="application/json">
                                 {
                                     "clef": "G-2",
-                                    "data": "'2A-//%F-4$xFC ,8B-4-2-/@3/2 '1C2-//"
+                                    "data": "'2A-//%F-4$xFC ,8B-4-2-/@3/2 '1C2-//",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>'2A-//%F-4$xFC ,8B-4-2-/@3/2 '1C2-//</code>
@@ -2402,7 +2486,8 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "3/2",
-                                    "data": "!{'8ABAG}!ff"
+                                    "data": "!{'8ABAG}!ff",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>!{'8ABAG}!ff</code>
@@ -2449,7 +2534,8 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "3/2",
-                                    "data": "'4ABAG/i/i/"
+                                    "data": "'4ABAG/i/i/",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>'4ABAG/i/i/</code>
@@ -2483,7 +2569,8 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "3/2",
-                                    "data": "'8.68{AB''C}{DEF}"
+                                    "data": "'8.68{AB''C}{DEF}",
+                                    "version": "pe2"
                                 }
                             </script>
                             <code>'8.68{AB''C}{DEF}</code>

--- a/v2/index.html
+++ b/v2/index.html
@@ -2620,10 +2620,12 @@
             but MAY contain any ASCII Graphic Character, as defined in [[RFC20]].
         </p>
         <p>
-            The value of the <code>@version</code> identifier MUST be <code>pe2</code> for incipits that conform
-            to Version 2 of the specification. If a <code>@version</code> identifier is not specified, or if any other
-            value other than <code>pe2</code> is found in the <code>@version</code> field, the incipit
-            MUST be interpreted as conforming to Version 1 of the Plaine and Easie Code.
+            The <code>@version</code> identifier MUST be present for encodings that conform to version 2 of the
+            specification, and the value of the <code>@version</code> identifier MUST be <code>pe2</code>. If
+            a <code>@version</code> identifier is not specified, or if any other value other than
+            <code>pe2</code> is found in the <code>@version</code> field, the incipit MUST be interpreted as
+            conforming to Version 1 of the Plaine and Easie Code. A value of <code>pe</code> MAY be used to identify
+            those encodings.
         </p>
         <aside class="example" title="Multi-line text with field delimiters">
             <pre>
@@ -2666,10 +2668,12 @@
             </p>
         </aside>
         <p>
-            The value of the <code>version</code> key MUST be <code>pe2</code> for incipits that conform
-            to Version 2 of the specification. If a <code>version</code> key is not specified, or if any other
-            value other than <code>pe2</code> is found in the <code>version</code> key, the incipit
-            MUST be interpreted as conforming to Version 1 of the specification.
+            The <code>version</code> key MUST be present for encodings that conform to version 2 of the
+            specification, and the value of the <code>version</code> key MUST be <code>pe2</code>. If
+            a <code>version</code> key is not specified, or if any other value other than
+            <code>pe2</code> is found in the <code>version</code> field, the incipit MUST be interpreted as
+            conforming to Version 1 of the Plaine and Easie Code. A value of <code>pe</code> MAY be used to identify
+            those encodings.
         </p>
         <aside class="example" title="JavaScript Object Notation (JSON)">
             <pre>
@@ -2691,7 +2695,8 @@
         </p>
         <p>
             This line MUST start with the string <code>;pe2</code> for incipits that
-            conform to Version 2 of the specification.
+            conform to Version 2 of the specification. Encodings that conform to an older version of the
+            specification MUST NOT contain a version identifier.
         </p>
         <p>
             Following the version declaration, the line MUST continue with a declaration of the clef.


### PR DESCRIPTION
A review of existing encodings revealed a few more discrepancies in the representations format section: 

 - `@end` was not defined in the multi-line text representation
 -  `@end` needed to have the fact that it *could* carry a label defined, and the fact that this could contain any string. 
 -  An equivalent to `@end` for JSON needed to be defined.
 -  (I didn't touch MARC, since it already has a note field...)
 - `@key` was removed from PAEC (#128) but it was still present in the representation formats section. It can still be included in representations, since other keys / fields are allowed, but it is no longer part of the PAEC.
 - The `version` key text was clarified, and a version value (taken from MARC) for PAEv1 was suggested
 - The encodings were updated to add a version string
