### PR TITLE
Fixed: Tuplet rework

### DIFF
--- a/static/js/verovio-rendering.js
+++ b/static/js/verovio-rendering.js
@@ -1,63 +1,126 @@
-document.addEventListener("DOMContentLoaded", (event) => {
-    verovio.module.onRuntimeInitialized = async _ => {
-        let tk = new verovio.toolkit();
-        tk.setOptions({
-            footer: 'none',
-            header: 'none',
-            breaks: 'auto',
-            pageMarginTop: 15,
-            pageMarginBottom: 15,
-            spacingSystem: 2,
-            pageMarginLeft: 0,
-            pageMarginRight: 0,
-            scale: 50,
-            adjustPageHeight: true,
-            adjustPageWidth: true,
-            svgHtml5: true,
-            // svgFormatRaw: true,
-            svgRemoveXlink: true,
-            // svgViewBox: true,
-            inputFrom: "pae"
+(() => {
+    "use strict";
+
+    const VEROVIO_OPTIONS = {
+        footer: "none",
+        header: "none",
+        breaks: "auto",
+        pageMarginTop: 15,
+        pageMarginBottom: 15,
+        spacingSystem: 2,
+        pageMarginLeft: 0,
+        pageMarginRight: 0,
+        scale: 50,
+        adjustPageHeight: true,
+        adjustPageWidth: true,
+        svgHtml5: true,
+        svgRemoveXlink: true,
+        inputFrom: "pae"
+    };
+
+    const EXAMPLE_SELECTOR = ".notation-example";
+    const CODE_SELECTOR = ".notation-code script[type='application/json']";
+    const FALLBACK_CODE_SELECTOR = "script[type='application/json']";
+    const RESULT_SELECTOR = ".notation-result, .rendered-notation";
+
+    function domReady() {
+        if (document.readyState !== "loading") {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            document.addEventListener("DOMContentLoaded", resolve, { once: true });
         });
+    }
 
-        let notationExamples = document.querySelectorAll("tr.notation-example");
-
-        if (notationExamples !== null)
-        {
-            for (let row of notationExamples)
-            {
-                let verovioSvg = "";
-
-                for (let column of row.children)
-                {
-                    if (column && column.classList.contains("notation-code"))
-                    {
-                        let paeCode = column.querySelector("script").textContent;
-                        let loadSuccess = tk.loadData(JSON.stringify(JSON.parse(paeCode)));
-
-                        if (loadSuccess)
-                        {
-                            verovioSvg = tk.renderToSVG();
-                        }
-                    }
-                    else if (column.classList.contains("notation-result"))
-                    {
-                        column.innerHTML = verovioSvg;
-                    }
-                    else if (column.classList.contains("rendered-notation"))
-                    {
-                        // This allows for both the code and the output to be shown in the same cell.
-                        let paeCode = column.querySelector("script").textContent;
-                        let loadSuccess = tk.loadData(JSON.stringify(JSON.parse(paeCode)));
-
-                        if (loadSuccess)
-                        {
-                            verovioSvg = tk.renderToSVG();
-                            column.innerHTML = verovioSvg;
-                        }
-                    }
-                }
+    function verovioReady() {
+        return new Promise((resolve, reject) => {
+            if (!window.verovio || !window.verovio.module) {
+                reject(new Error("Verovio module is not available."));
+                return;
             }
+
+            if (window.verovio.module.calledRun) {
+                resolve();
+                return;
+            }
+
+            const previousCallback = window.verovio.module.onRuntimeInitialized;
+
+            window.verovio.module.onRuntimeInitialized = (...args) => {
+                if (typeof previousCallback === "function") {
+                    previousCallback.apply(window.verovio.module, args);
+                }
+
+                resolve();
+            };
+        });
+    }
+
+    function getExampleData(example) {
+        const script = example.querySelector(CODE_SELECTOR)
+            || example.querySelector(FALLBACK_CODE_SELECTOR);
+
+        if (!script) {
+            return null;
+        }
+
+        return JSON.parse(script.textContent);
+    }
+
+    function getRenderTarget(example) {
+        return example.querySelector(RESULT_SELECTOR);
+    }
+
+    function renderExample(toolkit, example) {
+        const target = getRenderTarget(example);
+
+        if (!target) {
+            return;
+        }
+
+        let data;
+
+        try {
+            data = getExampleData(example);
+        } catch (error) {
+            target.innerHTML = "";
+            console.error("Could not parse notation example JSON.", { example, error });
+            return;
+        }
+
+        if (!data) {
+            return;
+        }
+
+        try {
+            const loaded = toolkit.loadData(JSON.stringify(data));
+
+            if (!loaded) {
+                target.innerHTML = "";
+                console.error("Verovio could not load notation example data.", { example, data });
+                return;
+            }
+
+            target.innerHTML = toolkit.renderToSVG();
+        } catch (error) {
+            target.innerHTML = "";
+            console.error("Could not render notation example.", { example, data, error });
         }
     }
-});
+
+    async function renderExamples() {
+        await Promise.all([domReady(), verovioReady()]);
+
+        const toolkit = new window.verovio.toolkit();
+        toolkit.setOptions(VEROVIO_OPTIONS);
+
+        for (const example of document.querySelectorAll(EXAMPLE_SELECTOR)) {
+            renderExample(toolkit, example);
+        }
+    }
+
+    renderExamples().catch((error) => {
+        console.error("Could not initialize Verovio example rendering.", error);
+    });
+})();

--- a/v2/index.html
+++ b/v2/index.html
@@ -1682,8 +1682,8 @@
                 <code>;</code> separates the notes of the tuplet from the tuplet number.
             </p>
             <p>
-                The tuplet number MAY be written as a single digit, or as a ratio of two positive integers separated by
-                a colon character <code>:</code>.
+                The tuplet number MAY be provided. If provided, it MUST be either a single positive integer,
+                or a ratio written as two positive integers separated by a colon character <code>:</code>.
             </p>
             <p>
                 If no tuplet number is provided, a value of <code>3</code> is implied.

--- a/v2/index.html
+++ b/v2/index.html
@@ -1733,7 +1733,7 @@
                 <code>;</code> separates the notes of the tuplet from the tuplet number.
             </p>
             <p>
-                The tuplet number MAY be provided. If provided, it MUST be either a single positive integer,
+                The tuplet number MAY be provided. If provided, it MUST be either a positive integer,
                 or a ratio written as two positive integers separated by a colon character <code>:</code>.
             </p>
             <p>

--- a/v2/index.html
+++ b/v2/index.html
@@ -1415,9 +1415,9 @@
             <h4>Rests</h4>
             <p>
                 Rests for single notes are indicated by a hyphen/minus character <code>-</code>. This character
-                MAY be preceded by a <a href="#durations">duration</a> value giving the musical duration of the rest.
-                If the duration is omitted, the last specified duration is used. If no duration is supplied in the
-                <a>encoding</a> a default duration of <code>4</code> is assumed.
+                MAY be preceded by a <a href="#durations">duration</a> value. If the duration is omitted, the last
+                specified duration is used. If no duration is supplied in the <a>encoding</a> a default duration
+                of <code>4</code> is assumed.
             </p>
             <aside class="example" title="Encoding Rests">
                 <table class="simple" style="width: 100%">

--- a/v2/index.html
+++ b/v2/index.html
@@ -1661,7 +1661,7 @@
                 Tuplets are enclosed within parentheses <code>()</code>.
             </p>
             <p>
-                A duration value MAY immediately follow the opening parenthesis <code>(</code>.
+                A <a href="#durations">duration value</a> MAY immediately follow the opening parenthesis <code>(</code>.
                 This value indicates the total musical duration occupied by the tuplet. A semicolon <code>;</code>
                 MUST immediately follow this duration value to separate it from any other duration value
                 given in the tuplet.

--- a/v2/index.html
+++ b/v2/index.html
@@ -119,7 +119,8 @@
             all: revert !important;
         }
 
-        .notation-result svg {
+        .notation-result svg,
+        .rendered-notation svg {
             background: white;
         }
 
@@ -1655,47 +1656,83 @@
             </aside>
         </section>
         <section id="tuplets">
-            <div class="issue" data-number="123"></div>
             <h4>Tuplets</h4>
             <p>
-                Tuplet groups are enclosed within parentheses <code>()</code>.
+                Tuplets are enclosed within parentheses <code>()</code>.
             </p>
             <p>
-                A tuplet group MUST begin with a duration value as the first character
-                after the opening parenthesis <code>(</code> to indicate the total duration
-                of the tuplet group.
+                A duration value MAY immediately precede the opening parenthesis <code>(</code>.
+                This value indicates the total duration occupied by the tuplet. If this
+                value is omitted, the total duration of the tuplet is not specified by the
+                encoding and MAY be inferred according to the current
+                <a href="#implied-duration-octave">implied duration</a>.
+            </p>
+            <p>
+                The first encoded note, rest, chord, or beam group within a tuplet MUST include
+                an explicit duration value. This value indicates the written duration of that logical
+                unit. Subsequent notes, rests, chords, or beam groups within the tuplet follow the
+                normal rules for implied or stated duration values.
+            </p>
+            <p>
+                A semicolon character <code>;</code> followed by a positive integer MAY be supplied
+                immediately before the closing parenthesis <code>)</code>. This integer indicates
+                the tuplet number displayed in brackets above the tuplet when rendered. If no tuplet
+                number is supplied, the value <code>3</code> is assumed.
+            </p>
+            <p>
+                The tuplet number MAY be written as a ratio of two positive integers separated by
+                a colon character <code>:</code>, such as <code>5:4</code>. The ratio is not a duration
+                value and MUST NOT be combined with a separate total-duration value inside the tuplet
+                marking.
+            </p>
+            <p>
+                Tuplets MUST NOT be used in Neume Notation.
             </p>
             <aside class="note">
                 <p>
-                    For example, if a tuplet has three eighth notes within the space of two,
-                    then the duration would be <code>4</code> to indicate the tuplet has a duration of
-                    one beat, assuming a quarter note is one beat in the time signature.
+                    In <code>4(6ABC;3)</code>, the value <code>4</code> before the opening
+                    parenthesis indicates the total duration occupied by the tuplet group. The
+                    value <code>6</code> after the opening parenthesis indicates that the encoded
+                    notes are written as sixteenth notes. The value <code>3</code> after the
+                    semicolon is the displayed tuplet number.
+                </p>
+                <p>
+                    Since the default displayed tuplet number is <code>3</code>, the encodings
+                    <code>8(6ABC;3)</code> and <code>8(6ABC)</code> are equivalent. Likewise,
+                    <code>8({6ABC};3)</code> and <code>8({6ABC})</code> are equivalent.
+                </p>
+                <p>
+                    Applications that render notation are free to choose how tuplet labels are
+                    displayed. They may choose to display the label only if explicitly provided,
+                    may choose to always display a label, or may choose to never show any tuplet labels.
+                    (The latter choice, however, may prove confusing for users.)
                 </p>
             </aside>
-            <p>
-                A semicolon character <code>;</code> and a positive integer MAY be the final character
-                before the closing parenthesis, <code>)</code>, of a tuplet group. This number indicates the number of
-                beat divisions in the group; that is, the number of beats that occur within
-                the tuplet in the space of the given duration value. If a number is not
-                given, a value of <code>3</code> is assumed.
-            </p>
-            <p>
-                A duration value MAY be given immediately preceding the opening parenthesis <code>(</code>.
-                This value indicates the rendered duration value for all notes within the tuplet, but has
-                no actual effect on the note duration. If no duration value is given, then the last stated duration
-                value is used. If no duration value is stated in the <a>encoding</a>, a default duration value of
-                <code>4</code> is assumed.
-            </p>
-            <aside class="note">
-                Since the default number of beats in the tuplet is <code>3</code>, these two
-                encodings of a triplet are considered to be equivalent:
-
-                <aside class="example">
-                    <pre class="code">
-                        8(6ABC;3) or 8({6ABC};3)
-                        8(6ABC) or 8({6ABC})
-                    </pre>
-                </aside>
+            <aside class="example" title="Illustrated Tuplet">
+                <p>
+                    Below is an annotated view of the tuplet structure and the equivalent rendering.
+                </p>
+                <pre>
+                    4('4D8E;3)
+                    | |  | | |
+                    | |  | | +-- displayed tuplet number
+                    | |  | +---- E is written as an eighth note
+                    | |  +------ D is written as a quarter note with an explicit duration
+                    | +--------- tuplet group begins
+                    +----------- total duration occupied by the tuplet group
+                </pre>
+                <div class="notation-example">
+                    <div class="notation-code">
+                        <script type="application/json">
+                            {
+                                "clef": "G-2",
+                                "timesig": "c",
+                                "data": "4('4D8E;3)/"
+                            }
+                        </script>
+                    </div>
+                    <div class="rendered-notation" style="text-align: center"></div>
+                </div>
             </aside>
             <aside class="example" title="Encoding Special Rhythmic Groupings">
                 <table class="simple" style="width: 100%">

--- a/v2/index.html
+++ b/v2/index.html
@@ -1769,7 +1769,7 @@
                      | |    |
                      | |    +-- displayed tuplet number (optional)
                      | +------- A B C as sixteenth notes
-                     +--------- sounding duration of the tuplet group (optional)
+                     +--------- sounding duration of the tuplet (optional)
                 </pre>
                 <div class="notation-example">
                     <div class="notation-code">

--- a/v2/index.html
+++ b/v2/index.html
@@ -254,9 +254,14 @@
             A software application that renders Plaine and Easie Code as music notation.
             A renderer may also produce sound output, for example through MIDI.
         </dd>
+        <dt><dfn>Sounding Duration</dfn></dt>
+        <dd>
+            The duration that is heard when the music is performed, which may be different from the
+            written duration value of the note.
+        </dd>
         <dt><dfn>Sounding Pitch</dfn></dt>
         <dd>
-            The pitch that is heard when the music is performed, independent of how that
+            The pitch that is heard when the music is performed, which may be different from the
             pitch is written on the staff.
         </dd>
         <dt><dfn>Staff</dfn></dt>
@@ -269,10 +274,15 @@
         <dd>
             The person or people who transcribe a musical source into Plaine and Easie Code.
         </dd>
+        <dt><dfn>Written Duration</dfn></dt>
+        <dd>
+            The duration of a note, according to its graphical appearance, which may differ from the
+            duration of the note when it is performed.
+        </dd>
         <dt><dfn>Written Pitch</dfn></dt>
         <dd>
-            The pitch represented by a note as it is written on the staff, independent of how
-            it sounds when performed.
+            The pitch represented by a note as it is written on the staff, which may differ from its pitch
+            when performed.
         </dd>
     </dl>
 </section>
@@ -1663,18 +1673,10 @@
             </p>
             <p>
                 A <a href="#durations">duration value</a> MAY immediately follow the opening parenthesis <code>(</code>.
-                This value indicates the total musical duration occupied by the tuplet. A semicolon <code>;</code>
+                This value indicates the total <a>sounding duration</a> occupied by the tuplet. A semicolon <code>;</code>
                 MUST immediately follow this duration value to separate it from any other duration value
                 given in the tuplet.
             </p>
-            <aside class="note">
-                <p>
-                    For tuplets, there is a distinction between the musical duration of the tuplet, and the
-                    written durations of individual notes within a tuplet. The former provides an optional way
-                    of specifying the duration of the tuplet with respect to the prevailing time signature, while the
-                    latter provides a way of specifying the visual form of the note.
-                </p>
-            </aside>
             <p>
                 A tuplet number MAY be provided before the closing parenthesis <code>)</code>. A semicolon
                 <code>;</code> separates the notes of the tuplet from the tuplet number.
@@ -1689,38 +1691,34 @@
             <p>
                 Tuplets MUST NOT be used in Neume Notation.
             </p>
-            <aside class="note">
+            <aside class="note" title="Tuplet encoding explained">
                 <p>
-                    In <code>(4;6ABC;3)</code>, the value <code>4;</code> after the opening
-                    parenthesis indicates the total duration occupied by the tuplet group. The
-                    value <code>6</code> after the total duration indicates that the encoded
-                    notes are written as sixteenth notes. The value <code>;3</code> after the
-                    semicolon is the tuplet number displayed in a bracket above the tuplet.
+                    In <code>(8;6ABC;3)</code>, the value <code>8;</code> after the opening
+                    parenthesis indicates the <a>sounding duration</a> occupied by the tuplet group. The
+                    value <code>6</code> after the total duration indicates the <a>written duration</a>
+                    as sixteenth notes. The value <code>;3</code> after the semicolon is the tuplet number
+                    displayed in a bracket above the tuplet.
                 </p>
                 <p>
                     Since the default displayed tuplet number is <code>3</code>, the encodings
                     <code>(8;6ABC;3)</code> and <code>(8;6ABC)</code> are equivalent. Likewise,
-                    <code>({8ABC};3)</code> and <code>({8ABC})</code> are equivalent.
+                    <code>({6ABC};3)</code> and <code>({6ABC})</code> are equivalent.
                 </p>
                 <p>
                     Applications that render notation are free to choose how tuplet labels are
                     displayed. They may choose to display the label only if explicitly provided,
-                    may choose to always display a label, or may choose to never show any tuplet labels.
-                    (The latter choice, however, may prove confusing for users.)
+                    may choose to always display a label using the implied default, or may choose
+                    to never show any tuplet labels.
                 </p>
-            </aside>
-            <aside class="example" title="Illustrated Tuplet">
                 <p>
                     Below is an annotated view of the tuplet structure and the equivalent rendering.
                 </p>
                 <pre>
-                    (4;'4D8E;3)
-                    | |  | | |
-                    | |  | | +-- displayed tuplet number
-                    | |  | +---- E is written as an eighth note
-                    | |  +------ D is written as a quarter note with an explicit duration
-                    | +--------- total duration occupied by the tuplet group
-                    +----------- tuplet group begins
+                    (8;6ABC;3)
+                     | |    |
+                     | |    +-- displayed tuplet number (optional)
+                     | +------- A B C as sixteenth notes
+                     +--------- sounding duration of the tuplet group (optional)
                 </pre>
                 <div class="notation-example">
                     <div class="notation-code">

--- a/v2/index.html
+++ b/v2/index.html
@@ -1661,45 +1661,45 @@
                 Tuplets are enclosed within parentheses <code>()</code>.
             </p>
             <p>
-                A duration value MAY immediately precede the opening parenthesis <code>(</code>.
-                This value indicates the total duration occupied by the tuplet. If this
-                value is omitted, the total duration of the tuplet is not specified by the
-                encoding and MAY be inferred according to the current
-                <a href="#implied-duration-octave">implied duration</a>.
+                A duration value MAY immediately follow the opening parenthesis <code>(</code>.
+                This value indicates the total musical duration occupied by the tuplet. A semicolon <code>;</code>
+                MUST immediately follow this duration value to separate it from any other duration value
+                given in the tuplet.
+            </p>
+            <aside class="note">
+                <p>
+                    For tuplets, there is a distinction between the musical duration of the tuplet, and the
+                    written durations of individual notes within a tuplet. The former provides an optional way
+                    of specifying the duration of the tuplet with respect to the prevailing time signature, while the
+                    latter provides a way of specifying the visual form of the note.
+                </p>
+            </aside>
+            <p>
+                A tuplet number MAY be provided before the closing parenthesis <code>)</code>. A semicolon
+                <code>;</code> separates the notes of the tuplet from the tuplet number.
             </p>
             <p>
-                The first encoded note, rest, chord, or beam group within a tuplet MUST include
-                an explicit duration value. This value indicates the written duration of that logical
-                unit. Subsequent notes, rests, chords, or beam groups within the tuplet follow the
-                normal rules for implied or stated duration values.
+                The tuplet number MAY be written as a single digit, or as a ratio of two positive integers separated by
+                a colon character <code>:</code>.
             </p>
             <p>
-                A semicolon character <code>;</code> followed by a positive integer MAY be supplied
-                immediately before the closing parenthesis <code>)</code>. This integer indicates
-                the tuplet number displayed in brackets above the tuplet when rendered. If no tuplet
-                number is supplied, the value <code>3</code> is assumed.
-            </p>
-            <p>
-                The tuplet number MAY be written as a ratio of two positive integers separated by
-                a colon character <code>:</code>, such as <code>5:4</code>. The ratio is not a duration
-                value and MUST NOT be combined with a separate total-duration value inside the tuplet
-                marking.
+                If no tuplet number is provided, a value of <code>3</code> is implied.
             </p>
             <p>
                 Tuplets MUST NOT be used in Neume Notation.
             </p>
             <aside class="note">
                 <p>
-                    In <code>4(6ABC;3)</code>, the value <code>4</code> before the opening
+                    In <code>(4;6ABC;3)</code>, the value <code>4;</code> after the opening
                     parenthesis indicates the total duration occupied by the tuplet group. The
-                    value <code>6</code> after the opening parenthesis indicates that the encoded
-                    notes are written as sixteenth notes. The value <code>3</code> after the
-                    semicolon is the displayed tuplet number.
+                    value <code>6</code> after the total duration indicates that the encoded
+                    notes are written as sixteenth notes. The value <code>;3</code> after the
+                    semicolon is the tuplet number displayed in a bracket above the tuplet.
                 </p>
                 <p>
                     Since the default displayed tuplet number is <code>3</code>, the encodings
-                    <code>8(6ABC;3)</code> and <code>8(6ABC)</code> are equivalent. Likewise,
-                    <code>8({6ABC};3)</code> and <code>8({6ABC})</code> are equivalent.
+                    <code>(8;6ABC;3)</code> and <code>(8;6ABC)</code> are equivalent. Likewise,
+                    <code>({8ABC};3)</code> and <code>({8ABC})</code> are equivalent.
                 </p>
                 <p>
                     Applications that render notation are free to choose how tuplet labels are
@@ -1713,13 +1713,13 @@
                     Below is an annotated view of the tuplet structure and the equivalent rendering.
                 </p>
                 <pre>
-                    4('4D8E;3)
+                    (4;'4D8E;3)
                     | |  | | |
                     | |  | | +-- displayed tuplet number
                     | |  | +---- E is written as an eighth note
                     | |  +------ D is written as a quarter note with an explicit duration
-                    | +--------- tuplet group begins
-                    +----------- total duration occupied by the tuplet group
+                    | +--------- total duration occupied by the tuplet group
+                    +----------- tuplet group begins
                 </pre>
                 <div class="notation-example">
                     <div class="notation-code">
@@ -1727,7 +1727,7 @@
                             {
                                 "clef": "G-2",
                                 "timesig": "c",
-                                "data": "4('4D8E;3)/"
+                                "data": "(4;'4D8E;3)/"
                             }
                         </script>
                     </div>
@@ -1750,10 +1750,10 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "c",
-                                    "data": "4(6'DEFGA;5)"
+                                    "data": "(4;6'DEFGA;5)"
                                 }
                             </script>
-                            <code>4(6'DEFGA;5)</code>
+                            <code>(4;6'DEFGA;5)</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>Quintuplet, 5 16th notes, in the space of a quarter note</td>
@@ -1764,10 +1764,10 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "c",
-                                    "data": "8({'3DEFGA};5)"
+                                    "data": "(8;{'3DEFGA};5)"
                                 }
                             </script>
-                            <code>8({'3DEFGA};5)</code>
+                            <code>(8;{'3DEFGA};5)</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>Quintuplet, 5 32nd notes, in the space of an eighth note, with beamed notes</td>
@@ -1778,10 +1778,10 @@
                                 {
                                     "clef": "G-2",
                                     "timesig": "c",
-                                    "data": "4('4D8E)4('4D8E)"
+                                    "data": "(4;'4D8E)(4;'4D8E)"
                                 }
                             </script>
-                            <code>4('4D8E)4('4D8E)</code>
+                            <code>(4;'4D8E)(4;'4D8E)</code>
                         </td>
                         <td class="notation-result"></td>
                         <td>Two triplet values of varying duration.</td>


### PR DESCRIPTION
I may have gotten some things wrong, so please review closely.

As part of this I have also had the Verovio rendering code re-worked. Primarily this was done to support the 'annotated tuplet' example provided, but it is also more flexible and resilient to encoding errors.

Fixes #123