### PR TITLE
Fixed: Clarify that octave and duration can appear in any order

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -822,13 +822,12 @@
                     <td>Octave</td>
                     <td><code>[,']{0,4}</code></td>
                     <td>Optional</td>
-                    <td></td>
+                    <td rowspan="2">Duration and octave MAY occur in any order</td>
                 </tr>
                 <tr>
                     <td>Duration / Duration Dot</td>
-                    <td><code>[0-9][.]{0,4}</code></td>
+                    <td><code>[0-9](.{0,4})</code></td>
                     <td>Optional</td>
-                    <td></td>
                 </tr>
                 <tr>
                     <td>Accidental</td>

--- a/v2/index.html
+++ b/v2/index.html
@@ -822,7 +822,7 @@
                     <td>Octave</td>
                     <td><code>[,']{0,4}</code></td>
                     <td>Optional</td>
-                    <td rowspan="2"> Duration and octave MAY occur in either order</td>
+                    <td rowspan="2">Duration and octave MAY occur in either order</td>
                 </tr>
                 <tr>
                     <td>Duration / Duration Dot</td>

--- a/v2/index.html
+++ b/v2/index.html
@@ -822,7 +822,7 @@
                     <td>Octave</td>
                     <td><code>[,']{0,4}</code></td>
                     <td>Optional</td>
-                    <td rowspan="2">Duration and octave MAY occur in any order</td>
+                    <td rowspan="2"> Duration and octave MAY occur in either order</td>
                 </tr>
                 <tr>
                     <td>Duration / Duration Dot</td>


### PR DESCRIPTION
This should resolve #97 where we can swap the order of octave / duration, but the other parts of the note "logical unit" must appear in a specific order. 